### PR TITLE
Fix code scanning alert no. 29: Unsafe jQuery plugin

### DIFF
--- a/themes/landscape/package.json
+++ b/themes/landscape/package.json
@@ -8,5 +8,8 @@
     "theme",
     "landscape"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "dompurify": "^3.2.3"
+  }
 }

--- a/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 /*!
  * fancyBox - jQuery Plugin
  * version: 2.1.5 (Fri, 14 Jun 2013)
@@ -1886,6 +1887,7 @@
 				return;
 			}
 
+			text = DOMPurify.sanitize(text);
 			title = $('<div class="fancybox-title fancybox-title-' + type + '-wrap">' + text + '</div>');
 
 			switch (type) {


### PR DESCRIPTION
Fixes [https://github.com/shenxianpeng/blog/security/code-scanning/29](https://github.com/shenxianpeng/blog/security/code-scanning/29)

To fix the problem, we need to ensure that any user-provided content is properly sanitized before being inserted into the DOM. This can be achieved by using a library like `DOMPurify` to sanitize the `text` content before constructing the `title` element. This will prevent any malicious scripts from being executed.

1. Import the `DOMPurify` library.
2. Sanitize the `text` content using `DOMPurify.sanitize` before constructing the `title` element.
3. Ensure that the sanitized content is used in the `title` element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
