### PR TITLE
Fix code scanning alert no. 29: Unsafe jQuery plugin

### DIFF
--- a/themes/landscape/source/fancybox/jquery.fancybox.js
+++ b/themes/landscape/source/fancybox/jquery.fancybox.js
@@ -1919,7 +1919,7 @@ import DOMPurify from 'dompurify';
 				break;
 			}
 
-			title[ (opts.position === 'top' ? 'prependTo'  : 'appendTo') ](target);
+			title.html(DOMPurify.sanitize(title.html()))[ (opts.position === 'top' ? 'prependTo'  : 'appendTo') ](target);
 		}
 	};
 


### PR DESCRIPTION
Fixes [https://github.com/shenxianpeng/blog/security/code-scanning/29](https://github.com/shenxianpeng/blog/security/code-scanning/29)

To fix the problem, we need to ensure that any user input passed through the `options` object is properly sanitized before it is used in the DOM. We can use the `DOMPurify` library, which is already imported, to sanitize the `title` content before it is appended or prepended to the `target`.

- Sanitize the `title` content using `DOMPurify.sanitize` before it is appended or prepended to the `target`.
- Ensure that the `title` content is safe to be inserted into the DOM.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
