### PR TITLE
post: add draft for commit-check AI attribution governance blog

### DIFF
--- a/draft/commit-check-ai-attribution/index.en.md
+++ b/draft/commit-check-ai-attribution/index.en.md
@@ -1,0 +1,204 @@
+---
+title: "Commit Check: AI Attribution Governance and Recent Highlights"
+summary: |
+  Commit Check v2.11.0 introduces AI attribution governance — a single config toggle that
+  rejects commits containing known AI tool signatures. This post also recaps important
+  updates from v2.5.0 through v2.10.0, including AI agent branch prefixes, force push
+  protection, output controls, and more.
+tags:
+  - Commit-Check
+  - DevOps
+  - AI
+authors:
+  - shenxianpeng
+date: 2026-07-06
+series: ["Commit Check"]
+series_order: 4
+---
+
+Hi everyone, I'm Shen Gong.
+
+It's been over half a year since the last Commit Check update post. Quite a few versions have shipped in that time, and today I'm writing to highlight what I think is the most important feature yet — plus a recap of everything else that's happened since v2.5.0.
+
+## The Big One: AI Attribution Governance
+
+Coming in v2.11.0 — **AI Attribution Governance**.
+
+What problem does this solve?
+
+As AI coding tools like Claude Code, GitHub Copilot, Cursor, Windsurf, and Devin become mainstream, the open-source community faces a new question: **how do we know whether a commit was written by a human or AI?**
+
+The Python community [discussed this](https://discuss.python.org/t/should-claude-codes-usage-be-described-in-the-code-docs-somewhere/107969) at length. The Linux kernel standardized on the `Assisted-by:` trailer format. VS Code has an open [issue](https://github.com/microsoft/vscode/issues/313962) debating whether to replace `Co-authored-by` with `Assisted-by` for AI agents.
+
+But until now, **no tool enforced these policies at the CI level.**
+
+Commit Check fills that gap.
+
+### Configuration
+
+A single binary switch — simple and backward compatible:
+
+```toml
+[commit]
+ai_attribution = "forbid"  # "ignore" is the default
+```
+
+Once set to `forbid`, Commit Check scans commit messages for known AI tool signatures and rejects any match.
+
+### Detected AI Tools
+
+The built-in signature database recognizes:
+
+| Tool | Patterns matched |
+|------|-----------------|
+| Claude Code | `Co-authored-by: Claude`, `Assisted-by: Claude:<model>`, `🤖 Generated with Claude`, `Claude-Session:`, `Claude-Workflow:` |
+| GitHub Copilot | `Co-authored-by: Copilot` |
+| OpenAI Codex | `Co-authored-by: Codex` |
+| Gemini | `Co-authored-by: Gemini` |
+| Cursor | `Co-authored-by: Cursor` |
+| Devin | `Co-authored-by: Devin` |
+| Aider | `Co-authored-by: Aider`, `Co-authored-by: ... (aider)` |
+| Windsurf | `Co-authored-by: Windsurf` |
+| Tabby | `Co-authored-by: Tabby` |
+| Generic AI | `Assisted-by: <tool>:<model>` (kernel style), model names (`claude-sonnet-4`, `gpt-4-turbo`) |
+
+### False Positive Prevention
+
+A practical concern: people named Claude or Devin exist. The implementation anchors Claude/Devin/Copilot patterns to known noreply email addresses, so human co-authors like `Co-authored-by: Jane Doe <jane@example.com>` are never flagged.
+
+### Multiple Integration Options
+
+Like all Commit Check features, AI attribution works across all interfaces:
+
+```bash
+# CLI
+commit-check --ai-attribution=forbid
+
+# Environment variable
+export CCHK_AI_ATTRIBUTION=forbid
+
+# TOML config
+[commit]
+ai_attribution = "forbid"
+
+# Python API
+from commit_check.api import validate_message
+result = validate_message(message, ai_attribution="forbid")
+```
+
+See the full PR at [commit-check/commit-check#456](https://github.com/commit-check/commit-check/pull/456). Feedback welcome!
+
+---
+
+## Recent Highlights (v2.5.0 — v2.10.0)
+
+Since the last update post, Commit Check has shipped a number of notable features. Here's a recap.
+
+### v2.9.0 — AI Agent Branch Prefixes
+
+The Conventional Branch v1.1.0 spec introduced AI agent branch prefixes: `ai/`, `claude/`, `codex/`, `copilot/`, and `cursor/`.
+
+In v2.9.0, these were added to `DEFAULT_BRANCH_TYPES` — branches like `claude/fix-bug-123` pass validation out of the box.
+
+### v2.7.0 — Force Push Protection
+
+A frequently requested feature: Commit Check now detects and blocks `git push --force` / `git push -f` via a `pre-push` hook.
+
+It uses `git merge-base --is-ancestor` to inspect the ancestry relationship. New branch pushes and fast-forwards pass normally; only true force pushes are blocked.
+
+```toml
+[push]
+allow_force_push = false  # default: true
+```
+
+Use it as a pre-commit hook:
+
+```yaml
+repos:
+  - repo: https://github.com/commit-check/commit-check
+    rev: v2.7.0
+    hooks:
+      - id: check-no-force-push
+        stages: [pre-push]
+```
+
+### v2.6.0 — Output Controls
+
+Two new CLI flags for quieter CI logs:
+
+- `--no-banner`: Suppress the ASCII art failure banner, keep detailed messages
+- `--compact`: Print one `[FAIL]` line per failing check, implies `--no-banner`
+
+### v2.5.0 — Multiple Practical Improvements
+
+**Co-author bypass in `ignore_authors`**
+
+When a co-author matches the ignore list, all commit checks are skipped — useful for AI-assisted workflows:
+
+```toml
+[commit]
+ignore_authors = ["dependabot[bot]", "renovate[bot]", "coderabbitai[bot]", "copilot[bot]"]
+```
+
+**Organization-level config inheritance (`inherit_from`)**
+
+Share a centralized base config across all repositories:
+
+```toml
+inherit_from = "github:my-org/.github:cchk.toml"
+
+[commit]
+subject_max_length = 72  # local override
+```
+
+**Git config author validation fix**
+
+Now checks `git config user.name / user.email` first — the identity for the *next* commit — instead of only the last commit's author.
+
+### v2.8.0 — Custom Regex & Python 3.9 Drop
+
+Two significant changes:
+
+**Custom regex support** via `message_pattern`:
+
+```toml
+[commit]
+message_pattern = "^(feat|fix|docs|chore|test)\\(.*\\):.*$"
+```
+
+**Python 3.9 support dropped**, enabling use of newer Python features.
+
+---
+
+## Housekeeping
+
+Beyond features, there were several maintenance improvements:
+
+- **Legacy YAML config code removed** (v2.10.1): Cleaned out the YAML compatibility layer from the v2.0 migration.
+- **OpenSSF Scorecard added** (v2.10.2): Check out the Scorecard badge in the repo.
+- **Bug fixes**: WIP commit detection case-insensitivity fix, special character support in Conventional Commit descriptions (v2.10.1).
+- **CI/CD improvements**: Migrated PyPI publishing to `pypa/gh-action-pypi-publish`.
+
+---
+
+## Closing Thoughts
+
+When I started Commit Check, I never imagined it would grow into what it is today.
+
+From commit messages and branch names, to author validation and sign-off checks, to merge-base verification and force push protection — and now AI attribution governance — it has evolved into a comprehensive compliance framework for the entire commit workflow.
+
+All driven by user feedback and community needs.
+
+If you haven't tried it yet, now is the perfect time:
+
+```bash
+pip install commit-check
+```
+
+📍 **Project**: github.com/commit-check/commit-check
+
+📄 **Docs**: https://commit-check.github.io/commit-check/
+
+---
+
+Please attribute the author when redistributing. For commercial use, please contact the author. Follow my WeChat public account 「沈显鹏」for updates.

--- a/draft/commit-check-ai-attribution/index.md
+++ b/draft/commit-check-ai-attribution/index.md
@@ -1,0 +1,215 @@
+---
+title: Commit Check 新功能：AI 归属治理与近期亮点回顾
+summary: |
+  Commit Check 在最新版本中引入了 AI 归属治理功能——通过配置 ai_attribution = "forbid"，可以拒绝包含已知 AI 工具签名的提交。
+  这篇博客也一并回顾了从 v2.5.0 到 v2.10.0 之间的多个重要更新，包括分支规范增强、强制推送保护、输出控制等。
+tags:
+  - Commit-Check
+  - DevOps
+  - AI
+authors:
+  - shenxianpeng
+date: 2026-07-06
+series: ["Commit Check"]
+series_order: 4
+---
+
+大家好，我是沈工。
+
+距离上次写 Commit Check 的更新已经过去大半年了。这段时间 Commit Check 发布了不少版本，今天趁着一个我觉得特别重要的新功能即将合入，写篇博客聊聊。
+
+## 先说最重要的：AI 归属治理
+
+即将在 v2.11.0 发布的核心功能——**AI 归属治理（AI Attribution Governance）**。
+
+这个功能解决什么问题呢？
+
+随着 Claude Code、GitHub Copilot、Cursor、Windsurf、Devin 等 AI 编程工具的普及，开源社区面临一个新问题：**如何知道一个提交是由人类还是 AI 写的？**
+
+Python 社区在 [discuss.python.org](https://discuss.python.org/t/should-claude-codes-usage-be-described-in-the-code-docs-somewhere/107969) 上专门讨论过这个问题，Linux Kernel 标准化了 `Assisted-by:` 格式，VS Code 也有相关的 [issue](https://github.com/microsoft/vscode/issues/313962) 讨论是否用 `Assisted-by` 替代 `Co-authored-by` 来标注 AI 贡献者。
+
+但问题是，目前没有一款工具能在 CI 层面自动执行这种策略。
+
+Commit Check 填补了这个空白。
+
+### 配置方式
+
+非常简单，只需一行配置：
+
+```toml
+[commit]
+ai_attribution = "forbid"  # "ignore" 为默认值，表示不检查
+```
+
+设置为 `forbid` 后，Commit Check 会检查提交消息中是否包含已知 AI 工具的特征签名。如果检测到，提交将被拒绝。
+
+### 支持检测的 AI 工具
+
+目前内置的签名库可以识别以下工具：
+
+| 工具 | 匹配模式 |
+|------|----------|
+| Claude Code | `Co-authored-by: Claude`、`Assisted-by: Claude:<model>`、`🤖 Generated with Claude`、`Claude-Session:`、`Claude-Workflow:` |
+| GitHub Copilot | `Co-authored-by: Copilot` |
+| OpenAI Codex | `Co-authored-by: Codex` |
+| Gemini | `Co-authored-by: Gemini` |
+| Cursor | `Co-authored-by: Cursor` |
+| Devin | `Co-authored-by: Devin` |
+| Aider | `Co-authored-by: Aider`、`Co-authored-by: ... (aider)` |
+| Windsurf | `Co-authored-by: Windsurf` |
+| Tabby | `Co-authored-by: Tabby` |
+| 通用 AI | `Assisted-by: <tool>:<model>` (Kernel 风格)、模型名称 (`claude-sonnet-4`、`gpt-4-turbo`) |
+
+### 误报防护
+
+实际使用中，很多人的名字就叫 Claude 或 Devin，如果不做区分就会出现误报。
+
+Commit Check 的方案是：针对 Claude、Devin、Copilot 等模式，**锚定到已知的 noreply 邮箱地址**，不会匹配到人类的 co-author。普通用户如 `Co-authored-by: Jane Doe <jane@example.com>` 永远不会被标记。
+
+### 多种集成方式
+
+和所有 Commit Check 功能一样，AI 归属治理支持：
+
+```bash
+# CLI 方式
+commit-check --ai-attribution=forbid
+
+# 环境变量
+export CCHK_AI_ATTRIBUTION=forbid
+
+# TOML 配置
+[commit]
+ai_attribution = "forbid"
+
+# Python API
+from commit_check.api import validate_message
+result = validate_message(message, ai_attribution="forbid")
+```
+
+详细的 PR 见 [commit-check/commit-check#456](https://github.com/commit-check/commit-check/pull/456)，欢迎 review 和反馈。
+
+---
+
+## 这段时间发布的亮点回顾
+
+自 v2.5.0 以来，Commit Check 还发布了不少实用的功能，这里一并回顾一下。
+
+### v2.9.0 — AI Agent 分支前缀默认支持
+
+Conventional Branch v1.1.0 规范中新增了 AI agent 相关的分支前缀：`ai/`、`claude/`、`codex/`、`copilot/`、`cursor/`。
+
+在 v2.9.0 中，这些前缀被直接加入到默认分支类型中，开箱即用，无需额外配置。
+
+如果你用 Claude Code 或 Copilot 创建分支，分支名如 `claude/fix-bug-123` 现在默认就能通过检查。
+
+### v2.7.0 — 强制推送保护
+
+这是一个很多团队呼声很高的功能。
+
+Commit Check 现在可以通过 `pre-push` hook 检测强制推送 (`git push --force` / `git push -f`)，并在检测到时阻止推送。
+
+原理是通过 `git merge-base --is-ancestor` 检查远程提交是否是本地提交的祖先。新分支推送、快进推送正常通过，只有真正的强制推送才会被拦截。
+
+```toml
+[push]
+allow_force_push = false  # 默认 true，设为 false 后阻止强制推送
+```
+
+这个功能作为 `pre-commit` 的 `pre-push` hook 使用：
+
+```yaml
+repos:
+  - repo: https://github.com/commit-check/commit-check
+    rev: v2.7.0
+    hooks:
+      - id: check-no-force-push
+        stages: [pre-push]
+```
+
+### v2.6.0 — 输出控制
+
+很多用户在 CI 日志中觉得提交检查的 banner 太长了。v2.6.0 新增了两个 CLI 标志：
+
+- `--no-banner`：去掉 ASCII 艺术 banner，保留详细错误信息
+- `--compact`：每个失败检查只输出一行 `[FAIL]`，同时隐含 `--no-banner`
+
+在 CI 日志或 pre-commit 输出中非常实用。
+
+### v2.5.0 — 多个实用更新
+
+这是 v2 系列中最重要的一个功能版本，包含三个重要更新：
+
+**Co-author 绕过支持**
+
+当 commit 的 co-author 匹配 `ignore_authors` 列表时，该提交可以跳过所有检查。特别适合 AI 辅助工作流：
+
+```toml
+[commit]
+ignore_authors = ["dependabot[bot]", "renovate[bot]", "coderabbitai[bot]", "copilot[bot]"]
+```
+
+**组织级配置继承（inherit_from）**
+
+团队现在可以共享一个中心化的基础配置：
+
+```toml
+# 每个仓库只需引用组织配置
+inherit_from = "github:my-org/.github:cchk.toml"
+
+[commit]
+subject_max_length = 72  # 局部覆盖
+```
+
+支持 GitHub raw 文件、本地路径、HTTPS URL 多种来源。
+
+**Git Config 作者验证修复**
+
+之前只检查最新提交的作者信息，现在优先检查 `git config user.name / user.email`——也就是**下一次提交**会使用的身份。解决了开发者配置了错误的 user.name 但仍然能通过检查的问题。
+
+### v2.8.0 — 自定义正则与 Python 3.9 告别
+
+v2.8.0 有两个重要变化：
+
+一是把用户呼声很高的自定义正则功能加了回来，通过 `message_pattern` 配置选项支持：
+
+```toml
+[commit]
+message_pattern = "^(feat|fix|docs|chore|test)\\(.*\\):.*$"
+```
+
+二是正式放弃了对 Python 3.9 的支持，让项目可以使用更新的 Python 特性。
+
+---
+
+## 一些维护上的工作
+
+除了上面的功能更新，这段时间还做了一些项目维护工作：
+
+- **移除了 YAML 配置的遗留代码**（v2.10.1）：随着 v2.0 全面转向 TOML 配置，终于把 YAML 的兼容代码清理干净了，项目代码更清爽。
+- **添加了 OpenSSF Scorecard**（v2.10.2）：提升了项目的安全合规水平，欢迎查看仓库的 Scorecard badge。
+- **修复了 WIP 提交检测的大小写问题**和 Convential Commit 描述中特殊字符的支持（v2.10.1）。
+- **CI/CD 改进**：迁移到 `pypa/gh-action-pypi-publish` 发布到 PyPI。
+
+---
+
+## 结语
+
+Commit Check 从诞生到现在，我最大的感受是——它已经不仅仅是一个"检查 commit message 的工具"了。
+
+从提交消息、分支命名、作者信息、签名验证，到合并基线检查、强制推送保护，再到现在的 AI 归属治理，它在逐渐成为一个覆盖代码提交全流程的合规检查框架。
+
+这也是我最初没有想到的——用户的反馈和社区的需求，推动着它一步步走到今天。
+
+如果你还没有用过 Commit Check，现在是最好的开始时机：
+
+```bash
+pip install commit-check
+```
+
+📍 项目地址：**github.com/commit-check/commit-check**
+
+📄 更多详情：https://commit-check.github.io/commit-check/
+
+---
+
+转载本站文章请注明作者和出处，请勿用于任何商业用途。欢迎关注公众号「沈显鹏」


### PR DESCRIPTION
## 概述

添加 Commit Check AI 归属治理（v2.11.0）的博客草稿，同时回顾 v2.5.0 至 v2.10.0 之间的重要更新。

## 文件

- `draft/commit-check-ai-attribution/index.md` — 中文版本
- `draft/commit-check-ai-attribution/index.en.md` — 英文版本

## 内容摘要

1. **核心内容**：介绍即将在 v2.11.0 发布的 AI 归属治理功能（PR [commit-check/commit-check#456](https://github.com/commit-check/commit-check/pull/456)）
2. **亮点回顾**：v2.5.0（co-author 绕过、inherit_from、Git config 验证）→ v2.6.0（输出控制）→ v2.7.0（强制推送保护）→ v2.8.0（自定义正则、Python 3.9 停止支持）→ v2.9.0（AI agent 分支前缀）→ v2.10.x（依赖分支默认支持、代码清理、Scorecard）

@Shenxianpeng 请 review，主要是确认内容准确性和风格是否符合预期。