### PR TITLE
docs: 补上封面图规范，修正 AGENTS.md 里和现状不符的内容

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,28 +9,49 @@ Instructions for AI coding agents working on this repository. This is a personal
 - **Languages:** Bilingual — Chinese (zh-cn, primary) + English (en)
 - **Content:** technical articles, personal essays, annual summaries
 - **Default language:** `zh-cn` (Chinese)
-- **Main sections:** `posts/`, `misc/`, `about/`
+- **Main sections:** `posts/` (technical articles), `misc/` (personal essays, annual
+  summaries), plus `about/`, `portfolio/`, `hireme/`, `archive/`, `tags/`, `authors/`
+- **Deployment:** GitHub Pages via `.github/workflows/pages.yaml`. Netlify runs
+  deploy previews on pull requests only — it is not the production host.
 
 ## Design System
 
-Always read `DESIGN.md` before making any visual or UI decisions.
-All font choices, colors, spacing, and aesthetic direction are defined there.
-Do not deviate without explicit user approval.
-In QA mode, flag any code that doesn't match `DESIGN.md`.
+**`DESIGN.md` is an unbuilt proposal, not a description of this site.** None of it
+is implemented: there is no custom CSS in the repository, and `Instrument Serif`,
+`#F8F4EF`, `#C84B2F` and `Fraunces` appear zero times outside that document. The
+live site runs stock Blowfish with the `slate` colour scheme and the theme's
+default fonts.
 
-Key design decisions to remember:
-- Body font is **Instrument Serif** (not a sans-serif — this is intentional and the core differentiator)
-- Background is **#F8F4EF** warm ivory in light mode (not pure white)
-- Accent color is **#C84B2F** terracotta orange (not blue, not purple)
-- Max content width is **680px** for article body
+So:
+
+- **Do not** treat a mismatch with `DESIGN.md` as a bug, and do not "fix" the site
+  to match it. Everything would look like a violation, because none of it was
+  ever built.
+- **Do not** start implementing `DESIGN.md` as a side effect of another task.
+  Adopting it is a large visual overhaul and needs the user to ask for it
+  explicitly.
+- Read it for intent — the editorial, restrained, typography-first direction is
+  real and worth respecting in any new UI.
+- If the user does adopt it, update this section; if they abandon it, delete
+  `DESIGN.md` so it stops misleading agents.
+
+For visual work today, the operative rule is simpler: **match the surrounding
+Blowfish styling.** Prefer a theme config option in `config/_default/params.toml`
+over new CSS, and prefer a `layouts/` override over touching
+`themes/blowfish/`.
 
 ## Writing Style & Tone
 
 ### Voice
 - **Conversational but disciplined.** Write like an experienced engineer explaining to a peer — direct, no fluff, but with genuine warmth.
 - **First-person is encouraged.** Use "我" freely. This is a personal blog, not corporate documentation.
-- **Opening style:** Posts typically open with "大家好，我是沈工" or a brief, engaging hook that draws the reader in.
-- **Closing style:** End with a personal sign-off (e.g., "老司机们，我们下期见～") and the standard footer:
+- **Opening style:** Open with a concrete hook — the problem, the surprising
+  number, the thing that actually happened ("今天打开 Gmail，看到一封来自
+  thanks.dev 的邮件"). Roughly 4% of posts open with "大家好，我是沈工"; it is an
+  occasional flourish, **not** the house style, so do not reach for it by default.
+- **Closing style:** A personal sign-off is welcome (e.g., "老司机们，我们下期见～").
+  About a third of posts also carry this footer — follow the convention of
+  neighbouring posts rather than adding it reflexively:
   ```
   转载本站文章请注明作者和出处，请勿用于任何商业用途。欢迎关注公众号「沈显鹏」
   ```
@@ -42,6 +63,42 @@ Key design decisions to remember:
 - Technical terms: keep common English acronyms (CI/CD, PR, API, AI, LLM) untranslated. Less common terms should have a Chinese explanation on first use.
 - **No emojis** in article body text. Emojis are acceptable in social media promotion but not in the article itself.
 - Keep paragraphs short — 3-5 sentences max. Mobile readers are a significant audience.
+
+### Avoiding AI slop
+
+The author maintains a Chinese-language skill for exactly this problem:
+**https://github.com/shenxianpeng/no-ai-slop**. Install and run it over any draft
+before proposing it. It has an edit mode (minimal fixes, preserves voice) and a
+detect mode (names the patterns it found and quotes them, no fake percentage
+scores).
+
+If you cannot install it, these are the rules it enforces. A draft that trips
+them is not ready:
+
+**Banned vocabulary** — Chinese business/tech filler, worn out from overuse:
+
+> 赋能、抓手、底层逻辑、顶层设计、闭环、打法、拉通、对齐、颗粒度、赛道、护城河、降维打击
+
+**Banned patterns:**
+
+| Pattern | Looks like |
+|---|---|
+| 废话开头 | "不得不说"、"有一说一"、"不可否认的是"、"说到底"、"毫无疑问" |
+| 伪洞察 | "很多人不知道的是"、"真正的关键在于" — casts the author as sole holder of the truth |
+| 二元对立 | "不是 X，而是 Y" as a reflex |
+| 否定列举 | "不是 A。不是 B。而是 C。" |
+| 冒号揭示 | "最关键的一点：它……" |
+| 模板化结构 | "首先……其次……最后……"; every paragraph summarising itself before expanding |
+| 表面分析 | "彰显了"、"体现了" standing in for actual analysis |
+| 重要性吹捧 | "标志着一个里程碑式的时刻"、"具有深远的意义"、"扮演着至关重要的角色" |
+| 模糊引用 | "专家表示"、"研究表明" with no named source |
+| 同义词轮换 | Cycling synonyms for the same thing within a paragraph to seem varied |
+| 伪深刻的结尾 | Forcing an aphorism at the end to elevate the piece |
+
+The underlying failure these describe: prose where every sentence is correct and
+nothing is memorable. Too smooth, too balanced, too complete. Concrete beats
+polished — a real number, a real error message, a real thing that went wrong is
+worth more than a paragraph of well-formed generalities.
 
 ### Units & Currency
 - **Use RMB (¥) for all monetary amounts**, not USD. Chinese readers are the primary audience.
@@ -55,6 +112,45 @@ Key design decisions to remember:
 - **Link generously.** Link to GitHub repos, documentation, reference articles — give readers paths to dive deeper.
 - **Respect the reader's time.** If a concept can be explained in 200 words, don't use 500.
 - **No clickbait.** Titles should accurately describe the content. The writing quality should sell itself.
+
+## Writing a New Post — End to End
+
+When asked to write a post, work in this order. Do not skip to drafting.
+
+1. **Establish the facts first.** Verify every version number, star count, repo
+   URL, and API detail against the actual source before writing a sentence about
+   it. Do not describe a tool's behaviour from memory. If a claim cannot be
+   checked, either cut it or attribute it explicitly.
+2. **Agree the angle before drafting.** State in one sentence what the post
+   argues and what the reader can do afterwards. A post that merely surveys a
+   topic is not worth publishing here.
+3. **Create the bundle:** `content/posts/YYYY/slug/index.md`, year matching the
+   post date. See the naming rules below.
+4. **Write the Chinese version.** This is the canonical text — never draft in
+   English and translate inward.
+5. **Run the draft through no-ai-slop** (see "Avoiding AI slop" above).
+6. **Add `featured.jpg`** — 1200×800, under 200 KB, no text in the image. See
+   "Images".
+7. **Translate to `index.en.md`** via `make translate`, then read the result.
+   Machine translation of technical Chinese needs a human-quality pass.
+8. **Run `make build`.** It catches broken refs, bad shortcodes, and missing
+   images. A post that does not build is not finished.
+9. **Work through the checklist** in "Before Committing".
+
+### What makes a post good here
+
+- **It comes from something that actually happened.** The strongest posts on this
+  blog start from a specific event — an email that arrived, a PR that got merged,
+  a bug that took three days. Lead with that, not with background.
+- **The numbers are real and specific.** "583 MB across 270 covers, median
+  2.5 MB" persuades; "the images were large" does not.
+- **It shows the work.** Commands, config, actual output, the failed attempt
+  before the one that worked.
+- **It admits limits.** What was not tried, what remains unsolved, where the
+  author was wrong. This is the single biggest differentiator from AI-written
+  technical content, which is relentlessly confident.
+- **It ends when the point is made.** No summary of what was just read, no
+  elevated closing aphorism.
 
 ## Content Organization
 
@@ -105,9 +201,23 @@ date: YYYY-MM-DD
 ### Rules
 - `title`: Full Chinese title. No English in Chinese titles unless it's a proper name/acronym (e.g., "CI/CD", "RepoKeeper").
 - `summary`: 2-3 sentences in Chinese. Use `|` for multi-line summaries. The summary appears on list pages and as SEO description.
-- `tags`: 2-5 relevant tags. Use existing tags when possible. Check `content/tags/` for the current tag list. Tags are shared across languages.
+- `tags`: 2-5 relevant tags, shared across languages. **Reuse an existing tag —
+  do not invent one.** `content/tags/` holds only the section index, not the tag
+  list; tags come from front matter, so list what is actually in use with:
+  ```bash
+  grep -rhA20 '^tags:' content --include=index.md | grep -E '^  - ' | sort | uniq -c | sort -rn
+  ```
+  There are already 158 distinct tags across 270 posts and 90 of them are used
+  exactly once, which is tag sprawl, not taxonomy. A new tag needs to be one you
+  expect to use again.
 - `authors`: Always `shenxianpeng` for the main author.
 - `date`: ISO format `YYYY-MM-DD`. This is the publication date.
+- `translate`: optional. Set `translate: false` to opt the post out of the
+  automatic English translation in `.github/auto_translate.py` — the script skips
+  any post whose front matter carries it. Used by 81 posts so far: pieces aimed
+  squarely at Chinese readers (公众号-oriented essays, Chinese-language tooling)
+  where an English version adds nothing. If you leave it off, the post is
+  expected to get an `index.en.md`.
 - **Never** include `draft: true` in published posts. Drafts should remain local only.
 
 ### English Front Matter
@@ -115,6 +225,56 @@ The `index.en.md` version should have:
 - `title`: Translated English title
 - `summary`: Translated English summary
 - Same `tags`, `authors`, `date` as the Chinese version
+
+## Images
+
+### Cover image (`featured.jpg`)
+
+Every post has one, in the post's own directory. It is **not** decoration: Hugo
+publishes it as the `og:image` and `twitter:image` for the post, and Blowfish
+also derives the list-page card thumbnail from it. Get it wrong and both the
+social preview and the article list suffer.
+
+| | |
+|---|---|
+| **Filename** | `featured.jpg` — exactly this, in the post bundle next to `index.md` |
+| **Dimensions** | **1200 × 800** (3:2), no exceptions |
+| **Format** | JPEG, quality 85, progressive |
+| **File size** | Target under 200 KB. Over 300 KB means something is wrong |
+
+Why 3:2 specifically: Blowfish renders cards with `.Resize "600x"` — it sets the
+width and lets the height follow the source aspect ratio. A square or portrait
+cover makes that one card taller than its neighbours and the grid loses its
+rhythm. Every cover being 3:2 is what keeps the list aligned.
+
+Why the size cap: this file is the `og:image`. Social crawlers fetch it with
+tight size and timeout limits, so a multi-megabyte cover risks the preview card
+simply not rendering. It is also the single easiest way to bloat the repo — the
+covers once totalled 583 MB at a 2.5 MB median.
+
+Content rules for covers:
+
+- **No text baked into the image.** It renders at 600px wide in a card and gets
+  cropped again by social platforms. Any text is illegible in both places, and
+  it cannot be translated for the English version.
+- **One clear subject**, readable as a thumbnail. Detailed diagrams and
+  screenshots do not survive the downscale — put those in the article body.
+- The established look is **flat vector-style illustration**: a single subject,
+  soft palette, clean outlines, no photorealism.
+- If you must adapt a non-3:2 source, letterbox it onto a blurred, darkened copy
+  of itself rather than cropping — cropping decapitates people and cuts off the
+  subject.
+
+### In-article images
+
+- Put them in the post directory and reference them relatively:
+  `![描述](screenshot.png)`
+- **Screenshots:** PNG is fine when text must stay crisp, but resize to **at most
+  1600px wide** and keep each file **under 500 KB**.
+- **Photos and illustrations:** JPEG quality 85.
+- Never commit an image straight from a phone, a screen-capture tool, or an image
+  generator without resizing first. Those routinely run 3–5 MB each.
+- Every image needs alt text.
 
 ## Bilingual Content Management
 


### PR DESCRIPTION
只改 `AGENTS.md` 一个文件。目的是让下次 AI 写文章时知道封面该做多大，顺便修掉几处会把 AI 带偏的描述。

## 封面规范（新增）

```
文件名   featured.jpg（就这个名字，和 index.md 同目录）
尺寸     1200 × 800（3:2），无例外
格式     JPEG，quality 85，渐进式
体积     目标 200 KB 以内，超过 300 KB 说明有问题
```

把**为什么**一起写进去了，否则下次还会被自作主张改掉：

- 这个文件同时是 `og:image` 和列表卡片缩略图的来源
- Blowfish 用 `.Resize "600x"` —— **只定宽、高度随源图比例**，所以非 3:2 的封面会让那张卡片比邻居高一截
- 社交平台抓取器对体积和超时都有限制，几 MB 的 OG 图有预览不出来的风险

内容上明确禁止**把文字烤进封面**：600px 的卡片和社交裁剪下都看不清，而且没法给英文版翻译。也写了非 3:2 素材的处理方式——用自身模糊暗化副本补边，不要裁。

另外补了**正文图片**规则（最宽 1600 px、单张 500 KB 以内），这是另一条让仓库膨胀的路径。

## 修正三处与现状不符的描述

**`DESIGN.md`（最要紧）** —— 原文写着「视觉决策必须遵循它」和「QA 模式下标记任何不符合它的代码」。但它一行都没实现：仓库里没有任何自定义 CSS，`Instrument Serif`、`#F8F4EF`、`#C84B2F`、`Fraunces` 在该文件之外出现 **0 次**，线上跑的是原版 Blowfish + `slate` 配色。按原来的措辞，agent 会把整站读成坏的然后动手"修"。现在标注为未实施的提案，并写明不要拿它当验收标准、也不要顺手开始实现。

**开头语** —— 原文说文章「通常以"大家好，我是沈工"开头」，实际是 **11 / 270**（4%）。

**页脚** —— 原文称转载声明为「标准页脚」，实际是 **98 / 270**（36%）。

后两条按真实频率重写，避免 agent 每篇都套。

## 补上两个空缺

- **`translate: false`** —— 81 篇在用，原文完全没提。这个字段决定 `.github/auto_translate.py` 跳不跳过该篇
- **标签** —— 原文让 agent 去 `content/tags/` 查现有标签，但那里只有 section 索引。改成给出能真正列出标签的命令，并写明现状：270 篇用了 158 个标签，其中 **90 个只用过一次**

## 写作指导

接到作者自己维护的中文版 [no-ai-slop](https://github.com/shenxianpeng/no-ai-slop) 上，而不是另起一套标准。写明让 agent 先装它跑一遍；装不了的情况下，把禁用词清单和 11 类中文 AI 套话模式内联成表格，保证标准一致。

另加一节端到端流程：**先核事实 → 定角度 → 建目录 → 写中文 → 过 no-ai-slop → 配封面 → 翻译 → `make build` → 走清单**。第一步刻意放最前面：版本号、star 数、仓库地址必须查证，不许凭记忆写。

## 待定

`.github/agents/post.agent.md` 目前是**空文件**。要么把上面这套写文章流程填进去，要么删掉——留着空文件对读到它的工具是噪音。这个 PR 没动它。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae6nzq8QQXqzdsigzF3ojY)_