### PR TITLE
feat(hireme): rewrite the resume page around verified facts

### DIFF
--- a/content/hireme/index.en.md
+++ b/content/hireme/index.en.md
@@ -22,9 +22,9 @@ layoutBackgroundHeaderSpace: false
 
 ## About Me
 
-DevOps / AI engineer based in Vilnius, Lithuania. Sixteen years in software engineering across the full arc — QA, test automation, then DevOps — with build, release, and delivery automation at Rocket Software since 2015. Currently building enterprise **Agentic DevOps** applications: AI agents that understand code, invoke tools, and complete real engineering tasks inside controlled workflows.
+DevOps / AI engineer based in Vilnius, Lithuania. Sixteen years in software engineering, from QA and test automation to DevOps, with build, release, and delivery automation at Rocket Software since 2015. My current focus is **Digital Colleague** and **AI Code Review**: AI that takes on real engineering tasks under controlled workflows.
 
-Outside work I'm an active open source author. I created and maintain six GitHub organizations, and my tools run daily in the CI of hundreds of projects — including **Microsoft, Apache, NASA, Samsung, Bloomberg, and Qualcomm**.
+Outside work I maintain six GitHub organizations, and my tools run daily in the CI of hundreds of projects — including **Microsoft, Apache, NASA, Samsung, Bloomberg, and Qualcomm**.
 
 **Highlights**
 
@@ -32,7 +32,7 @@ Outside work I'm an active open source author. I created and maintain six GitHub
 - Author of an **official Jenkins plugin** ([Explain Error](https://github.com/jenkinsci/explain-error-plugin)); member of the Jenkins GitHub organization
 - Selected for the **Anthropic Open Source Developer Program** (2026)
 - **EuroPython 2025** proposal reviewer
-- 250+ original technical articles ([blog](https://shenxianpeng.github.io/en/) + WeChat), plus a weekly engineering newsletter since 2026
+- 250+ original technical articles ([blog](https://shenxianpeng.github.io/en/) + WeChat)
 
 ---
 
@@ -40,9 +40,9 @@ Outside work I'm an active open source author. I created and maintain six GitHub
 
 **Senior DevOps Engineer** | Rocket Software, Lithuania | _Jul 2024 – Present_
 
-- Build enterprise **Agentic Applications** on the **GitHub Copilot SDK**: task-executing AI agents that connect code understanding, task orchestration, tool invocation, and feedback loops into developers' daily workflows.
-- Put AI into concrete CI/CD steps — automated build-failure analysis, code maintenance, documentation updates. In the pipeline, not in a demo.
-- Drive the pairing of mature DevOps practice with AI-assisted tooling across the team's delivery system.
+- Build an enterprise **Digital Colleague**: AI agents on the **GitHub Copilot SDK** that take on engineering tasks, connecting code understanding, task orchestration, tool invocation, and feedback.
+- Build **AI Code Review**: AI-based review integrated into the team's PR workflow.
+- Own the team's CI/CD and delivery infrastructure.
 
 **DevOps Engineer** | Rocket Software, Dalian | _2015 – Jun 2024_
 
@@ -64,32 +64,32 @@ Outside work I'm an active open source author. I created and maintain six GitHub
 
 **[cpp-linter](https://github.com/cpp-linter)** — C/C++ code quality automation: clang-format and clang-tidy delivered as a GitHub Action and pre-commit hook. Runs in the daily CI of hundreds of projects, including Microsoft, Apache, NASA, Samsung, Bloomberg, Qualcomm, and Jupyter.
 
-**[commit-check](https://github.com/commit-check)** — a policy engine for Git commit metadata: one versioned TOML policy validating commit messages, branch names, author identity, signoff trailers, and **AI attribution**, shared across local hooks, CI, GitHub Actions, and AI automation.
+**[commit-check](https://github.com/commit-check)** — a policy engine for Git commit metadata: one versioned TOML policy validating commit messages, branch names, author identity, signoff trailers, and **AI attribution**, shared across local hooks, CI, and GitHub Actions.
 
-**[conventional-branch](https://github.com/conventional-branch)** — a branch naming specification and toolset; since 1.1.0 it natively supports **AI Coding Agent** branch prefixes, one convention for repositories where humans and AI ship together.
+**[conventional-branch](https://github.com/conventional-branch)** — a branch naming specification and toolset; since 1.1.0 it natively supports **AI Coding Agent** branch prefixes.
 
 **[Explain Error](https://github.com/jenkinsci/explain-error-plugin)** — an official Jenkins plugin that uses AI to explain build failures, with **AI Auto-Fix** (automatic repair PRs), usage statistics and quota controls, and providers including OpenAI, Gemini, Azure OpenAI, DeepSeek, Qwen, Ollama, and AWS Bedrock.
 
 **[Open Delivery Spec](https://github.com/open-delivery-spec)** — an open specification and toolset for detecting, analyzing, and governing AI-generated code: AI-code detection, quality scoring, and policy gates that run as a CI quality gate (every PR on this blog's repository goes through it).
 
-**More**: [devops-maturity](https://github.com/devops-maturity) (DevOps maturity assessment and badges), [MkDocs NG](https://github.com/mkdocs-ng) (community continuation of the MkDocs ecosystem), [gitstats](https://github.com/shenxianpeng/gitstats) (Git repository analytics), [jenkinsfilelint](https://github.com/shenxianpeng/jenkinsfilelint) (Jenkinsfile validation without a Jenkins server).
+**More**: [devops-maturity](https://github.com/devops-maturity) (DevOps maturity assessment and badges), [MkDocs NG](https://github.com/mkdocs-ng) (community maintenance of the MkDocs ecosystem), [gitstats](https://github.com/shenxianpeng/gitstats) (Git repository analytics), [jenkinsfilelint](https://github.com/shenxianpeng/jenkinsfilelint) (Jenkinsfile validation without a Jenkins server).
 
 ---
 
 ## Skills
 
 - **Engineering practice**: CI/CD, build & release, containers (Docker / Kubernetes), infrastructure as code (Ansible), code quality & coverage, software supply chain security (SLSA / SBOM)
-- **AI engineering**: agentic application development, GitHub Copilot SDK, LLM integration (OpenAI / Gemini / Bedrock / Ollama and others), AI code governance
+- **AI engineering**: Digital Colleague / agentic application development, AI Code Review, GitHub Copilot SDK, LLM integration (OpenAI / Gemini / Bedrock / Ollama and others)
 - **Languages**: Python, Shell, Groovy, Go
 - **Platforms**: Jenkins, GitHub Actions, Linux, Windows, and enterprise environments including AIX
 
 ---
 
-## Community & Writing
+## Community
 
-- **Writing**: 250+ original technical articles on DevOps, AI, CI/CD, and open source; a weekly engineering newsletter since 2026
-- **Community**: EuroPython 2025 proposal reviewer; attended PyCon Lithuania 2025 with full three-day conference coverage; maintainer in the Jenkins and MkDocs ecosystems
-- **Recognition**: Anthropic Open Source Developer Program; GitHub Arctic Code Vault Contributor
+- **EuroPython 2025** proposal reviewer; attended **PyCon Lithuania 2025** and published three days of conference notes
+- Maintainer in the **Jenkins** and **MkDocs** ecosystems
+- Anthropic Open Source Developer Program; GitHub Arctic Code Vault Contributor
 
 ---
 
@@ -108,8 +108,6 @@ Outside work I'm an active open source author. I created and maintain six GitHub
 ---
 
 ## Contact
-
-If your team is looking for an engineer who lands AI in the delivery pipeline — not in a demo — let's talk:
 
 - Email: [xianpeng.shen@gmail.com](mailto:xianpeng.shen@gmail.com)
 - GitHub: [@shenxianpeng](https://github.com/shenxianpeng)

--- a/content/hireme/index.en.md
+++ b/content/hireme/index.en.md
@@ -22,66 +22,74 @@ layoutBackgroundHeaderSpace: false
 
 ## About Me
 
-- **DevOps / Build / Release / AI Engineering practitioner** focused on software delivery, developer experience, and engineering automation.
-- Specialized in DevOps since 2018, with hands-on experience across Windows, Linux, AIX, Solaris, HP-UX, and the full software development lifecycle.
-- Exploring **Agentic DevOps** and AI-assisted developer tooling in enterprise environments, connecting AI agents, CI/CD, code understanding, and task execution into practical engineering workflows.
-- Strong in the **Scan → Try → Scale** approach: evaluate promising practices, validate them in real teams, then scale what works.
-- Proficient in **Python / Shell / Groovy** for building DevOps tools, automation systems, and AI-assisted engineering solutions.
-- **Open Source Creator and Maintainer**: Founded and maintain [cpp-linter](https://github.com/cpp-linter), [commit-check](https://github.com/commit-check), [conventional-branch](https://github.com/conventional-branch), and [devops-maturity](https://github.com/devops-maturity), and contribute to the Jenkins and MkDocs ecosystems.
-- **Technical Writer**: Published hundreds of original articles on my [blog](https://shenxianpeng.github.io) and WeChat public account **沈显鹏**, sharing practical experience in DevOps, AI, CI/CD, and open source.
+DevOps / AI engineer based in Vilnius, Lithuania. Sixteen years in software engineering across the full arc — QA, test automation, then DevOps — with build, release, and delivery automation at Rocket Software since 2015. Currently building enterprise **Agentic DevOps** applications: AI agents that understand code, invoke tools, and complete real engineering tasks inside controlled workflows.
+
+Outside work I'm an active open source author. I created and maintain six GitHub organizations, and my tools run daily in the CI of hundreds of projects — including **Microsoft, Apache, NASA, Samsung, Bloomberg, and Qualcomm**.
+
+**Highlights**
+
+- [cpp-linter](https://github.com/cpp-linter), my C/C++ quality tooling, is used by hundreds of notable projects including Microsoft, Apache, NASA, Samsung, Bloomberg, Qualcomm, and Jupyter
+- Author of an **official Jenkins plugin** ([Explain Error](https://github.com/jenkinsci/explain-error-plugin)); member of the Jenkins GitHub organization
+- Selected for the **Anthropic Open Source Developer Program** (2026)
+- **EuroPython 2025** proposal reviewer
+- 250+ original technical articles ([blog](https://shenxianpeng.github.io/en/) + WeChat), plus a weekly engineering newsletter since 2026
 
 ---
 
 ## Work Experience
 
 **Senior DevOps Engineer** | Rocket Software, Lithuania | _Jul 2024 – Present_
-- Develop enterprise **Agentic Applications** that explore GitHub Copilot / @Copilot-like task execution experiences, where AI agents can understand context, invoke tools, and assist with engineering tasks inside controlled workflows.
-- Integrate the **GitHub Copilot SDK** and Skill invocation capabilities on the backend, connecting code understanding, task orchestration, tool execution, and feedback loops for developers.
-- Drive DevOps + AI practices across CI/CD, build failure analysis, code maintenance, documentation workflows, and developer productivity.
-- Continue scaling delivery practices by combining mature DevOps patterns with AI-assisted tooling in day-to-day engineering workflows.
+
+- Build enterprise **Agentic Applications** on the **GitHub Copilot SDK**: task-executing AI agents that connect code understanding, task orchestration, tool invocation, and feedback loops into developers' daily workflows.
+- Put AI into concrete CI/CD steps — automated build-failure analysis, code maintenance, documentation updates. In the pipeline, not in a demo.
+- Drive the pairing of mature DevOps practice with AI-assisted tooling across the team's delivery system.
 
 **DevOps Engineer** | Rocket Software, Dalian | _2015 – Jun 2024_
-- Led CI/CD transformation from manual/Bamboo builds to **Jenkins with shared libraries**.
-- Built **IaC with Ansible** for provisioning Jenkins and development environments.
-- **Dockerized** MVAS products using buildx, health checks, and Kubernetes deployments.
-- Proposed and scaled **DevOps maturity badge** and **conventional commits**.
+
+- Led CI/CD transformation across multiple product lines: from manual and Bamboo builds to **Jenkins with shared libraries**, all build logic as code.
+- Built infrastructure as code with **Ansible** for provisioning Jenkins and development environments.
+- Containerized enterprise products: multi-arch builds with buildx, health checks, **Kubernetes** deployments.
+- Designed the **DevOps maturity badge** system and scaled it to department level; drove **Conventional Commits** adoption across teams.
 - Automated VM management with Jira + Python, adopted company-wide.
-- Enabled **code coverage** reporting for multiple product lines.
-- Won multiple Rocket Build Awards and added solutions to product roadmap.
+- Introduced **code coverage** reporting for multiple product lines.
+- Multiple **Rocket Build Awards**; several solutions adopted into product roadmaps.
 
-**Software Engineer in Test** | JD.COM, Beijing | _2012 – 2014_
-- Developed automated test scripts and maintained CI pipelines.
+**Software Engineer in Test** | JD.COM, Beijing | _2012 – 2014_ — automated testing and CI pipelines.
 
-**QA Engineer** | SIMCOM (Shanghai) & Neusoft (Beijing) | _2009 – 2011_
-- Designed and executed test cases; led small QA teams and shared best practices.
+**QA Engineer** | SIMCOM (Shanghai) & Neusoft (Beijing) | _2009 – 2011_ — test design and execution; led small QA teams.
 
 ---
 
 ## Open Source Projects
 
-- **[cpp-linter](https://github.com/cpp-linter)** — A suite of C/C++ code quality tools integrating clang-format and clang-tidy, available as a GitHub Action and pre-commit hook. Adopted by hundreds of notable projects including Microsoft, Apache, and NASA. [cpp-linter-action](https://github.com/cpp-linter/cpp-linter-action) is among the most recognized C/C++ linting solutions on GitHub.
+**[cpp-linter](https://github.com/cpp-linter)** — C/C++ code quality automation: clang-format and clang-tidy delivered as a GitHub Action and pre-commit hook. Runs in the daily CI of hundreds of projects, including Microsoft, Apache, NASA, Samsung, Bloomberg, Qualcomm, and Jupyter.
 
-- **[commit-check](https://github.com/commit-check)** — A flexible Git convention checker that validates commit messages, branch names, and author information. Supports GitHub Actions, pre-commit, and CLI usage, helping teams keep Git workflows consistent.
+**[commit-check](https://github.com/commit-check)** — a policy engine for Git commit metadata: one versioned TOML policy validating commit messages, branch names, author identity, signoff trailers, and **AI attribution**, shared across local hooks, CI, GitHub Actions, and AI automation.
 
-- **[conventional-branch](https://github.com/conventional-branch)** — A specification and toolset for standardizing Git branch naming conventions, including validators and GitHub Actions for open source projects and engineering teams.
+**[conventional-branch](https://github.com/conventional-branch)** — a branch naming specification and toolset; since 1.1.0 it natively supports **AI Coding Agent** branch prefixes, one convention for repositories where humans and AI ship together.
 
-- **[devops-maturity](https://github.com/devops-maturity)** — A framework for assessing and communicating DevOps maturity through structured specs and badge systems, helping teams measure progress and drive continuous improvement.
+**[Explain Error](https://github.com/jenkinsci/explain-error-plugin)** — an official Jenkins plugin that uses AI to explain build failures, with **AI Auto-Fix** (automatic repair PRs), usage statistics and quota controls, and providers including OpenAI, Gemini, Azure OpenAI, DeepSeek, Qwen, Ollama, and AWS Bedrock.
 
-- **[explain-error-plugin](https://github.com/jenkinsci/explain-error-plugin)** — An official Jenkins plugin that uses AI to explain build failures and now supports AI Auto-Fix for creating repair PRs, usage statistics and quota controls, and multiple providers including OpenAI, Gemini, Azure OpenAI, DeepSeek, Qwen, Ollama, and AWS Bedrock.
+**[Open Delivery Spec](https://github.com/open-delivery-spec)** — an open specification and toolset for detecting, analyzing, and governing AI-generated code: AI-code detection, quality scoring, and policy gates that run as a CI quality gate (every PR on this blog's repository goes through it).
 
-- **[MkDocs NG](https://github.com/mkdocs-ng)** — Maintains `mkdocs-ng` and `mkdocs-ng-material` to keep the MkDocs and Material for MkDocs ecosystem usable, with bug fixes, dependency upgrades, Python compatibility work, and a migration path that preserves the original CLI, configuration file, and plugin interfaces.
-
-- **[gitstats](https://github.com/shenxianpeng/gitstats)** — A Git repository analytics tool that visualizes contribution patterns, commit frequency, contributor activity, and code trends. Version 2.0 moved the chart engine to Chart.js and added responsive UI, dark/light mode, and AI-generated repository insights.
+**More**: [devops-maturity](https://github.com/devops-maturity) (DevOps maturity assessment and badges), [MkDocs NG](https://github.com/mkdocs-ng) (community continuation of the MkDocs ecosystem), [gitstats](https://github.com/shenxianpeng/gitstats) (Git repository analytics), [jenkinsfilelint](https://github.com/shenxianpeng/jenkinsfilelint) (Jenkinsfile validation without a Jenkins server).
 
 ---
 
 ## Skills
 
-- DevOps / CI/CD / Build & Release ★★★★★
-- AI-assisted tooling / Agentic DevOps / LLM applications ★★★★☆
-- Jenkins / Docker / Ansible / GitHub Actions ★★★★☆
-- Python / Shell / Groovy ★★★★☆
-- Go / GitHub Copilot SDK / Open Source Maintenance ★★★☆☆
+- **Engineering practice**: CI/CD, build & release, containers (Docker / Kubernetes), infrastructure as code (Ansible), code quality & coverage, software supply chain security (SLSA / SBOM)
+- **AI engineering**: agentic application development, GitHub Copilot SDK, LLM integration (OpenAI / Gemini / Bedrock / Ollama and others), AI code governance
+- **Languages**: Python, Shell, Groovy, Go
+- **Platforms**: Jenkins, GitHub Actions, Linux, Windows, and enterprise environments including AIX
+
+---
+
+## Community & Writing
+
+- **Writing**: 250+ original technical articles on DevOps, AI, CI/CD, and open source; a weekly engineering newsletter since 2026
+- **Community**: EuroPython 2025 proposal reviewer; attended PyCon Lithuania 2025 with full three-day conference coverage; maintainer in the Jenkins and MkDocs ecosystems
+- **Recognition**: Anthropic Open Source Developer Program; GitHub Arctic Code Vault Contributor
 
 ---
 
@@ -101,4 +109,7 @@ layoutBackgroundHeaderSpace: false
 
 ## Contact
 
+If your team is looking for an engineer who lands AI in the delivery pipeline — not in a demo — let's talk:
+
 - Email: [xianpeng.shen@gmail.com](mailto:xianpeng.shen@gmail.com)
+- GitHub: [@shenxianpeng](https://github.com/shenxianpeng)

--- a/content/hireme/index.en.md
+++ b/content/hireme/index.en.md
@@ -22,9 +22,9 @@ layoutBackgroundHeaderSpace: false
 
 ## About Me
 
-DevOps / AI engineer based in Vilnius, Lithuania. Sixteen years in software engineering, from QA and test automation to DevOps, with build, release, and delivery automation at Rocket Software since 2015. My current focus is **Digital Colleague** and **AI Code Review**: AI that takes on real engineering tasks under controlled workflows.
+DevOps / AI engineer based in Vilnius, Lithuania. Sixteen years in software engineering, from QA and test automation to DevOps, with build, release, and delivery automation at Rocket Software since 2015. My current focus is enterprise **agentic applications**: AI that takes on real engineering tasks under controlled workflows.
 
-Outside work I maintain six GitHub organizations, and my tools run daily in the CI of hundreds of projects — including **Microsoft, Apache, NASA, Samsung, Bloomberg, and Qualcomm**.
+Outside work I maintain a number of open source organizations and projects, and my tools run daily in the CI of hundreds of projects — including **Microsoft, Apache, NASA, Samsung, Bloomberg, and Qualcomm**.
 
 **Highlights**
 
@@ -40,8 +40,8 @@ Outside work I maintain six GitHub organizations, and my tools run daily in the 
 
 **Senior DevOps Engineer** | Rocket Software, Lithuania | _Jul 2024 – Present_
 
-- Build an enterprise **Digital Colleague**: AI agents on the **GitHub Copilot SDK** that take on engineering tasks, connecting code understanding, task orchestration, tool invocation, and feedback.
-- Build **AI Code Review**: AI-based review integrated into the team's PR workflow.
+- Build enterprise **agentic applications**: AI agents on the **GitHub Copilot SDK** that take on engineering tasks, connecting code understanding, task orchestration, tool invocation, and feedback.
+- Bring AI into everyday engineering steps such as code review and build-failure analysis.
 - Own the team's CI/CD and delivery infrastructure.
 
 **DevOps Engineer** | Rocket Software, Dalian | _2015 – Jun 2024_
@@ -78,8 +78,8 @@ Outside work I maintain six GitHub organizations, and my tools run daily in the 
 
 ## Skills
 
-- **Engineering practice**: CI/CD, build & release, containers (Docker / Kubernetes), infrastructure as code (Ansible), code quality & coverage, software supply chain security (SLSA / SBOM)
-- **AI engineering**: Digital Colleague / agentic application development, AI Code Review, GitHub Copilot SDK, LLM integration (OpenAI / Gemini / Bedrock / Ollama and others)
+- **Engineering practice**: CI/CD, build & release, containers (Docker), infrastructure as code (Ansible), code quality & coverage, software supply chain security (SLSA / SBOM)
+- **AI engineering**: agentic application development, AI code review, GitHub Copilot SDK, LLM integration (OpenAI / Gemini / Bedrock / Ollama and others)
 - **Languages**: Python, Shell, Groovy, Go
 - **Platforms**: Jenkins, GitHub Actions, Linux, Windows, and enterprise environments including AIX
 
@@ -89,7 +89,7 @@ Outside work I maintain six GitHub organizations, and my tools run daily in the 
 
 - **EuroPython 2025** proposal reviewer; attended **PyCon Lithuania 2025** and published three days of conference notes
 - Maintainer in the **Jenkins** and **MkDocs** ecosystems
-- Anthropic Open Source Developer Program; GitHub Arctic Code Vault Contributor
+- Anthropic Open Source Developer Program
 
 ---
 

--- a/content/hireme/index.md
+++ b/content/hireme/index.md
@@ -24,17 +24,17 @@ layoutBackgroundHeaderSpace: false
 
 ## 个人简介
 
-DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经验，走过 QA → 测试开发 → DevOps 的完整路径，2015 年起在 Rocket Software 深耕构建、发布与交付自动化，目前负责企业级 **Agentic DevOps** 应用开发——让 AI agent 在受控工作流中理解代码、调用工具、完成真实的工程任务。
+DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经验，从 QA、测试开发一路做到 DevOps，2015 年起在 Rocket Software 负责构建、发布与交付自动化。目前的工作重心是 **Digital Colleague（数字同事）** 与 **AI Code Review**：让 AI 以受控的方式承担真实的工程任务。
 
-业余是活跃的开源作者：创建并维护 6 个开源组织，我写的工具每天跑在 **Microsoft、Apache、NASA、Samsung、Bloomberg、Qualcomm** 等数百个项目的 CI 里。
+业余维护 6 个开源组织，写的工具每天跑在 **Microsoft、Apache、NASA、Samsung、Bloomberg、Qualcomm** 等数百个项目的 CI 里。
 
 **核心亮点**
 
-- 开源 C/C++ 质量工具 [cpp-linter](https://github.com/cpp-linter) 被数百个知名项目采用，包括 Microsoft、Apache、NASA、Samsung、Bloomberg、Qualcomm、Jupyter
+- 开源 C/C++ 质量工具 [cpp-linter](https://github.com/cpp-linter) 被 Microsoft、Apache、NASA、Samsung、Bloomberg、Qualcomm、Jupyter 等数百个项目采用
 - Jenkins **官方插件**（[Explain Error](https://github.com/jenkinsci/explain-error-plugin)）作者，Jenkins GitHub 组织成员
 - **Anthropic Open Source Developer Program** 入选者（2026）
 - **EuroPython 2025** 议题评审
-- 累计发布 250+ 篇原创技术文章（[博客](https://shenxianpeng.github.io) + 公众号「沈显鹏」），2026 年起周更《攻城狮周刊》
+- 累计发布 250+ 篇原创技术文章（[博客](https://shenxianpeng.github.io) + 公众号「沈显鹏」）
 
 ---
 
@@ -42,9 +42,9 @@ DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经�
 
 **高级 DevOps 工程师** | Rocket Software，立陶宛 | _2024.07 – 至今_
 
-- 开发企业级 **Agentic Application**：基于 **GitHub Copilot SDK** 构建任务执行型 AI agent，连接代码理解、任务编排、工具调用与结果反馈，服务开发者日常工作流。
-- 把 AI 落进 CI/CD 的具体环节：构建失败自动分析、代码维护、文档更新——不是做演示，是进流水线。
-- 在团队内推动成熟 DevOps 实践与 AI 辅助工具的结合，持续改进交付体系。
+- 开发企业级 **Digital Colleague**：基于 **GitHub Copilot SDK** 构建承担工程任务的 AI agent，连接代码理解、任务编排、工具调用与结果反馈。
+- 建设 **AI Code Review**：将 AI 代码审查接入团队的 PR 工作流。
+- 同时负责团队 CI/CD 与交付基础设施的持续建设。
 
 **DevOps 工程师** | Rocket Software，大连 | _2015 – 2024.06_
 
@@ -53,7 +53,7 @@ DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经�
 - 容器化企业级产品：buildx 多架构构建、健康检查、**Kubernetes** 部署。
 - 设计 **DevOps 成熟度徽章**体系并推广到部门级；推动 **Conventional Commits** 在多团队落地。
 - 用 Jira + Python 自动化虚拟机管理，被全公司采用。
-- 为多条产品线引入**代码覆盖率**报告，让质量可见。
+- 为多条产品线引入**代码覆盖率**报告。
 - 多次获得 **Rocket Build Award**，多项方案被纳入产品路线图。
 
 **测试开发工程师** | 京东，北京 | _2012 – 2014_ — 自动化测试与持续集成流水线。
@@ -66,32 +66,32 @@ DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经�
 
 **[cpp-linter](https://github.com/cpp-linter)** — C/C++ 代码质量自动化：clang-format + clang-tidy，以 GitHub Action 和 pre-commit hook 交付。被 Microsoft、Apache、NASA、Samsung、Bloomberg、Qualcomm、Jupyter 等数百个项目用于日常 CI。
 
-**[commit-check](https://github.com/commit-check)** — Git 提交元数据的策略引擎：一份版本化的 TOML 策略，统一校验提交信息、分支命名、作者身份、signoff 与 **AI 署名**，在本地 hook、CI、GitHub Actions 与 AI 自动化之间共享同一套规则。
+**[commit-check](https://github.com/commit-check)** — Git 提交元数据的策略引擎：一份版本化的 TOML 策略，统一校验提交信息、分支命名、作者身份、signoff 与 **AI 署名**，在本地 hook、CI、GitHub Actions 之间共享同一套规则。
 
-**[conventional-branch](https://github.com/conventional-branch)** — Git 分支命名规范与工具集，1.1.0 起原生支持 **AI Coding Agent** 分支前缀，为人和 AI 共存的仓库提供统一约定。
+**[conventional-branch](https://github.com/conventional-branch)** — Git 分支命名规范与工具集，1.1.0 起原生支持 **AI Coding Agent** 分支前缀。
 
 **[Explain Error](https://github.com/jenkinsci/explain-error-plugin)** — Jenkins 官方插件：AI 分析构建失败原因，支持 **AI Auto-Fix 自动创建修复 PR**、用量统计与配额管控，兼容 OpenAI、Gemini、Azure OpenAI、DeepSeek、Qwen、Ollama、AWS Bedrock 等 Provider。
 
 **[Open Delivery Spec](https://github.com/open-delivery-spec)** — 检测、分析和治理 AI 生成代码的开源规范与工具集：AI 代码检出、质量评分、策略门禁，作为 CI 质量门运行（本博客仓库的每个 PR 都在用它）。
 
-**其他**：[devops-maturity](https://github.com/devops-maturity)（DevOps 成熟度评估与徽章）、[MkDocs NG](https://github.com/mkdocs-ng)（延续 MkDocs 生态的社区维护）、[gitstats](https://github.com/shenxianpeng/gitstats)（Git 仓库统计可视化）、[jenkinsfilelint](https://github.com/shenxianpeng/jenkinsfilelint)（无需 Jenkins 服务器的 Jenkinsfile 校验）。
+**其他**：[devops-maturity](https://github.com/devops-maturity)（DevOps 成熟度评估与徽章）、[MkDocs NG](https://github.com/mkdocs-ng)（MkDocs 生态的社区维护）、[gitstats](https://github.com/shenxianpeng/gitstats)（Git 仓库统计可视化）、[jenkinsfilelint](https://github.com/shenxianpeng/jenkinsfilelint)（无需 Jenkins 服务器的 Jenkinsfile 校验）。
 
 ---
 
 ## 技能
 
 - **工程实践**：CI/CD、构建与发布、容器化（Docker / Kubernetes）、基础设施即代码（Ansible）、代码质量与覆盖率、软件供应链安全（SLSA / SBOM）
-- **AI 工程**：Agentic 应用开发、GitHub Copilot SDK、LLM 集成（OpenAI / Gemini / Bedrock / Ollama 等）、AI 代码治理
+- **AI 工程**：Digital Colleague / Agentic 应用开发、AI Code Review、GitHub Copilot SDK、LLM 集成（OpenAI / Gemini / Bedrock / Ollama 等）
 - **语言**：Python、Shell、Groovy、Go
 - **平台**：Jenkins、GitHub Actions、Linux、Windows、AIX 等企业级环境
 
 ---
 
-## 社区与分享
+## 社区
 
-- **写作**：250+ 篇原创技术文章，覆盖 DevOps、AI、CI/CD 与开源实践；《攻城狮周刊》每周更新
-- **社区**：EuroPython 2025 议题评审；PyCon Lithuania 2025 全程参会并发布三篇大会记录；Jenkins、MkDocs 生态维护者
-- **认可**：Anthropic Open Source Developer Program 入选者；GitHub Arctic Code Vault Contributor
+- **EuroPython 2025** 议题评审；**PyCon Lithuania 2025** 参会并发布三篇大会记录
+- **Jenkins、MkDocs** 生态维护者
+- Anthropic Open Source Developer Program 入选者；GitHub Arctic Code Vault Contributor
 
 ---
 
@@ -110,8 +110,6 @@ DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经�
 ---
 
 ## 联系我
-
-如果你的团队在找一个能把 AI 真正落进交付流程、而不是停在演示阶段的工程师，欢迎联系：
 
 - 邮箱：[xianpeng.shen@gmail.com](mailto:xianpeng.shen@gmail.com)
 - GitHub：[@shenxianpeng](https://github.com/shenxianpeng)

--- a/content/hireme/index.md
+++ b/content/hireme/index.md
@@ -24,9 +24,9 @@ layoutBackgroundHeaderSpace: false
 
 ## 个人简介
 
-DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经验，从 QA、测试开发一路做到 DevOps，2015 年起在 Rocket Software 负责构建、发布与交付自动化。目前的工作重心是 **Digital Colleague（数字同事）** 与 **AI Code Review**：让 AI 以受控的方式承担真实的工程任务。
+DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经验，从 QA、测试开发一路做到 DevOps，2015 年起在 Rocket Software 负责构建、发布与交付自动化。目前专注企业级 **Agentic 应用**开发，让 AI 以受控的方式承担真实的工程任务。
 
-业余维护 6 个开源组织，写的工具每天跑在 **Microsoft、Apache、NASA、Samsung、Bloomberg、Qualcomm** 等数百个项目的 CI 里。
+业余维护多个开源组织和项目，写的工具每天跑在 **Microsoft、Apache、NASA、Samsung、Bloomberg、Qualcomm** 等数百个项目的 CI 里。
 
 **核心亮点**
 
@@ -42,8 +42,8 @@ DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经�
 
 **高级 DevOps 工程师** | Rocket Software，立陶宛 | _2024.07 – 至今_
 
-- 开发企业级 **Digital Colleague**：基于 **GitHub Copilot SDK** 构建承担工程任务的 AI agent，连接代码理解、任务编排、工具调用与结果反馈。
-- 建设 **AI Code Review**：将 AI 代码审查接入团队的 PR 工作流。
+- 开发企业级 **Agentic 应用**：基于 **GitHub Copilot SDK** 构建承担工程任务的 AI agent，连接代码理解、任务编排、工具调用与结果反馈。
+- 将 AI 引入代码审查、构建失败分析等日常工程环节。
 - 同时负责团队 CI/CD 与交付基础设施的持续建设。
 
 **DevOps 工程师** | Rocket Software，大连 | _2015 – 2024.06_
@@ -80,8 +80,8 @@ DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经�
 
 ## 技能
 
-- **工程实践**：CI/CD、构建与发布、容器化（Docker / Kubernetes）、基础设施即代码（Ansible）、代码质量与覆盖率、软件供应链安全（SLSA / SBOM）
-- **AI 工程**：Digital Colleague / Agentic 应用开发、AI Code Review、GitHub Copilot SDK、LLM 集成（OpenAI / Gemini / Bedrock / Ollama 等）
+- **工程实践**：CI/CD、构建与发布、容器化（Docker）、基础设施即代码（Ansible）、代码质量与覆盖率、软件供应链安全（SLSA / SBOM）
+- **AI 工程**：Agentic 应用开发、AI 代码审查、GitHub Copilot SDK、LLM 集成（OpenAI / Gemini / Bedrock / Ollama 等）
 - **语言**：Python、Shell、Groovy、Go
 - **平台**：Jenkins、GitHub Actions、Linux、Windows、AIX 等企业级环境
 
@@ -91,7 +91,7 @@ DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经�
 
 - **EuroPython 2025** 议题评审；**PyCon Lithuania 2025** 参会并发布三篇大会记录
 - **Jenkins、MkDocs** 生态维护者
-- Anthropic Open Source Developer Program 入选者；GitHub Arctic Code Vault Contributor
+- Anthropic Open Source Developer Program 入选者
 
 ---
 

--- a/content/hireme/index.md
+++ b/content/hireme/index.md
@@ -24,66 +24,74 @@ layoutBackgroundHeaderSpace: false
 
 ## 个人简介
 
-- **DevOps / Build / Release / AI Engineering 工程师**，长期关注软件交付效率、开发者体验与工程自动化。
-- 自 2018 年起专注 DevOps，熟悉 Windows、Linux、AIX、Solaris、HP-UX 等操作系统及完整软件生命周期。
-- 在企业环境中推动 **Agentic DevOps** 与 AI-assisted developer tooling 探索，将 AI agents、CI/CD、代码理解与任务执行能力结合到开发工作流中。
-- 擅长 **Scan → Try → Scale** 方法，将行业最佳实践从小范围验证推广到团队和部门级落地。
-- 熟练使用 Python / Shell / Groovy 构建 DevOps 工具、自动化系统与 AI 辅助开发解决方案。
-- **开源作者与维护者**：创建并维护 [cpp-linter](https://github.com/cpp-linter)、[commit-check](https://github.com/commit-check)、[conventional-branch](https://github.com/conventional-branch)、[devops-maturity](https://github.com/devops-maturity) 等项目，并参与 Jenkins、MkDocs 生态相关开源维护。
-- **技术分享者**：在 [博客](https://shenxianpeng.github.io) 与公众号 "**沈显鹏**" 发布数百篇原创文章，持续分享 DevOps、AI、CI/CD 与开源实践。
+DevOps / AI 工程师，现居立陶宛维尔纽斯。十六年软件工程经验，走过 QA → 测试开发 → DevOps 的完整路径，2015 年起在 Rocket Software 深耕构建、发布与交付自动化，目前负责企业级 **Agentic DevOps** 应用开发——让 AI agent 在受控工作流中理解代码、调用工具、完成真实的工程任务。
+
+业余是活跃的开源作者：创建并维护 6 个开源组织，我写的工具每天跑在 **Microsoft、Apache、NASA、Samsung、Bloomberg、Qualcomm** 等数百个项目的 CI 里。
+
+**核心亮点**
+
+- 开源 C/C++ 质量工具 [cpp-linter](https://github.com/cpp-linter) 被数百个知名项目采用，包括 Microsoft、Apache、NASA、Samsung、Bloomberg、Qualcomm、Jupyter
+- Jenkins **官方插件**（[Explain Error](https://github.com/jenkinsci/explain-error-plugin)）作者，Jenkins GitHub 组织成员
+- **Anthropic Open Source Developer Program** 入选者（2026）
+- **EuroPython 2025** 议题评审
+- 累计发布 250+ 篇原创技术文章（[博客](https://shenxianpeng.github.io) + 公众号「沈显鹏」），2026 年起周更《攻城狮周刊》
 
 ---
 
 ## 工作经历
 
-**高级 DevOps 工程师** | Rocket Software, 立陶宛 | _2024.07 - 至今_
-- 负责企业级 **Agentic Application** 开发，探索类似 GitHub Copilot / @Copilot 的任务执行型开发体验，让 AI agents 能在受控工作流中理解上下文、调用工具并协助完成工程任务。
-- 在后端集成 **GitHub Copilot SDK** 与 Skill 调用能力，将代码理解、任务编排、工具执行和结果反馈连接到开发者工作流中。
-- 推动 DevOps + AI 实践落地，聚焦 CI/CD、构建失败分析、代码维护、文档更新与开发者效率提升。
-- 继续建设可扩展的交付体系，将成熟 DevOps 实践与 AI-assisted tooling 结合到团队日常工程流程中。
+**高级 DevOps 工程师** | Rocket Software，立陶宛 | _2024.07 – 至今_
 
-**DevOps 工程师** | Rocket Software, 大连 | _2015 - 2024.06_
-- 推动配置即代码（CaC）：将手工/Bamboo 构建迁移到 Jenkins，并构建共享库。
-- 构建 **Ansible** 基础设施即代码（IaC），自动部署 Jenkins 与开发环境。
-- **容器化** MV 产品：支持 buildx、多架构、Kubernetes 部署。
-- 提出并推广 **DevOps 成熟度徽章** 与 **Conventional Commits**。
-- 使用 Jira + Python 自动化管理虚拟机，全公司范围使用。
-- 为多条产品线引入 **代码覆盖率** 报告。
-- 多次获得 **Rocket Build 奖项**，并将方案纳入产品路线图。
+- 开发企业级 **Agentic Application**：基于 **GitHub Copilot SDK** 构建任务执行型 AI agent，连接代码理解、任务编排、工具调用与结果反馈，服务开发者日常工作流。
+- 把 AI 落进 CI/CD 的具体环节：构建失败自动分析、代码维护、文档更新——不是做演示，是进流水线。
+- 在团队内推动成熟 DevOps 实践与 AI 辅助工具的结合，持续改进交付体系。
 
-**测试开发工程师** | 京东, 北京 | _2012 - 2014_
-- 编写自动化测试脚本，维护持续集成流水线。
+**DevOps 工程师** | Rocket Software，大连 | _2015 – 2024.06_
 
-**QA 工程师** | SIMCOM（上海）& 东软（北京） | _2009 - 2011_
-- 设计并执行测试用例，带领小型 QA 团队并推广测试方法。
+- 主导 CI/CD 转型：多条产品线从手工构建和 Bamboo 迁移到 **Jenkins + 共享库**，构建逻辑全部代码化。
+- 用 **Ansible** 实现基础设施即代码，自动化部署 Jenkins 与开发环境。
+- 容器化企业级产品：buildx 多架构构建、健康检查、**Kubernetes** 部署。
+- 设计 **DevOps 成熟度徽章**体系并推广到部门级；推动 **Conventional Commits** 在多团队落地。
+- 用 Jira + Python 自动化虚拟机管理，被全公司采用。
+- 为多条产品线引入**代码覆盖率**报告，让质量可见。
+- 多次获得 **Rocket Build Award**，多项方案被纳入产品路线图。
+
+**测试开发工程师** | 京东，北京 | _2012 – 2014_ — 自动化测试与持续集成流水线。
+
+**QA 工程师** | SIMCOM（上海）、东软（北京） | _2009 – 2011_ — 测试用例设计与执行，带领小型 QA 团队。
 
 ---
 
 ## 开源项目
 
-- **[cpp-linter](https://github.com/cpp-linter)** — C/C++ 代码质量自动化工具，集成 clang-format（格式化）与 clang-tidy（静态分析），支持 GitHub Actions 与 pre-commit。已被微软、Apache、NASA 等数百个知名项目采用，[cpp-linter-action](https://github.com/cpp-linter/cpp-linter-action) 在 GitHub 上广受好评。
+**[cpp-linter](https://github.com/cpp-linter)** — C/C++ 代码质量自动化：clang-format + clang-tidy，以 GitHub Action 和 pre-commit hook 交付。被 Microsoft、Apache、NASA、Samsung、Bloomberg、Qualcomm、Jupyter 等数百个项目用于日常 CI。
 
-- **[commit-check](https://github.com/commit-check)** — Git 提交规范检查工具，支持校验提交信息、分支名称、作者信息等，兼容 GitHub Actions、pre-commit 及命令行，帮助团队统一 Git 工作流。
+**[commit-check](https://github.com/commit-check)** — Git 提交元数据的策略引擎：一份版本化的 TOML 策略，统一校验提交信息、分支命名、作者身份、signoff 与 **AI 署名**，在本地 hook、CI、GitHub Actions 与 AI 自动化之间共享同一套规则。
 
-- **[conventional-branch](https://github.com/conventional-branch)** — Git 分支命名规范倡议与工具集，提供规范定义、验证工具与 GitHub Actions，帮助开源项目和工程团队统一分支命名约定。
+**[conventional-branch](https://github.com/conventional-branch)** — Git 分支命名规范与工具集，1.1.0 起原生支持 **AI Coding Agent** 分支前缀，为人和 AI 共存的仓库提供统一约定。
 
-- **[devops-maturity](https://github.com/devops-maturity)** — DevOps 成熟度评估规范与徽章系统，帮助团队量化评估 DevOps 落地水平，并以可视化方式推动持续改进。
+**[Explain Error](https://github.com/jenkinsci/explain-error-plugin)** — Jenkins 官方插件：AI 分析构建失败原因，支持 **AI Auto-Fix 自动创建修复 PR**、用量统计与配额管控，兼容 OpenAI、Gemini、Azure OpenAI、DeepSeek、Qwen、Ollama、AWS Bedrock 等 Provider。
 
-- **[explain-error-plugin](https://github.com/jenkinsci/explain-error-plugin)** — Jenkins 官方插件，利用 AI 自动分析构建失败原因，并支持 AI Auto-Fix 自动创建修复 PR、用量统计与配额管控，以及 OpenAI、Gemini、Azure OpenAI、DeepSeek、Qwen、Ollama、AWS Bedrock 等多种 Provider。
+**[Open Delivery Spec](https://github.com/open-delivery-spec)** — 检测、分析和治理 AI 生成代码的开源规范与工具集：AI 代码检出、质量评分、策略门禁，作为 CI 质量门运行（本博客仓库的每个 PR 都在用它）。
 
-- **[MkDocs NG](https://github.com/mkdocs-ng)** — 维护 `mkdocs-ng` 与 `mkdocs-ng-material`，延续 MkDocs 与 Material for MkDocs 生态，修复 bug、升级依赖、适配新版 Python，并保持原 CLI、配置文件与插件接口兼容，降低用户迁移成本。
-
-- **[gitstats](https://github.com/shenxianpeng/gitstats)** — Git 仓库贡献数据可视化工具，生成提交频率、贡献者分布、代码行数变化等统计报告。2.0 版本将图表引擎迁移到 Chart.js，支持响应式 UI、深浅色模式与 AI 生成的仓库洞察摘要。
+**其他**：[devops-maturity](https://github.com/devops-maturity)（DevOps 成熟度评估与徽章）、[MkDocs NG](https://github.com/mkdocs-ng)（延续 MkDocs 生态的社区维护）、[gitstats](https://github.com/shenxianpeng/gitstats)（Git 仓库统计可视化）、[jenkinsfilelint](https://github.com/shenxianpeng/jenkinsfilelint)（无需 Jenkins 服务器的 Jenkinsfile 校验）。
 
 ---
 
 ## 技能
 
-- DevOps / CI/CD / Build & Release ★★★★★
-- AI-assisted tooling / Agentic DevOps / LLM 应用 ★★★★☆
-- Jenkins / Docker / Ansible / GitHub Actions ★★★★☆
-- Python / Shell / Groovy ★★★★☆
-- Go / GitHub Copilot SDK / Open Source Maintenance ★★★☆☆
+- **工程实践**：CI/CD、构建与发布、容器化（Docker / Kubernetes）、基础设施即代码（Ansible）、代码质量与覆盖率、软件供应链安全（SLSA / SBOM）
+- **AI 工程**：Agentic 应用开发、GitHub Copilot SDK、LLM 集成（OpenAI / Gemini / Bedrock / Ollama 等）、AI 代码治理
+- **语言**：Python、Shell、Groovy、Go
+- **平台**：Jenkins、GitHub Actions、Linux、Windows、AIX 等企业级环境
+
+---
+
+## 社区与分享
+
+- **写作**：250+ 篇原创技术文章，覆盖 DevOps、AI、CI/CD 与开源实践；《攻城狮周刊》每周更新
+- **社区**：EuroPython 2025 议题评审；PyCon Lithuania 2025 全程参会并发布三篇大会记录；Jenkins、MkDocs 生态维护者
+- **认可**：Anthropic Open Source Developer Program 入选者；GitHub Arctic Code Vault Contributor
 
 ---
 
@@ -91,7 +99,7 @@ layoutBackgroundHeaderSpace: false
 
 - 中文 — 母语
 - 英语 — 专业工作水平
-- 立陶宛语 — 初级 (A1)
+- 立陶宛语 — 初级（A1）
 
 ---
 
@@ -103,4 +111,7 @@ layoutBackgroundHeaderSpace: false
 
 ## 联系我
 
+如果你的团队在找一个能把 AI 真正落进交付流程、而不是停在演示阶段的工程师，欢迎联系：
+
 - 邮箱：[xianpeng.shen@gmail.com](mailto:xianpeng.shen@gmail.com)
+- GitHub：[@shenxianpeng](https://github.com/shenxianpeng)

--- a/content/misc/2025-summary/index.en.md
+++ b/content/misc/2025-summary/index.en.md
@@ -1,3 +1,4 @@
+---
 title: 2025 Year-End Summary
 tags:
   - Thoughts

--- a/content/posts/2025/devops-tools/index.en.md
+++ b/content/posts/2025/devops-tools/index.en.md
@@ -1,3 +1,4 @@
+---
 title: Understand DevOps in One Article—This is How Packer, Terraform, Docker, and K8s Divide Their Work!
 summary: In the world of DevOps, with so many tools, many people get confused about their responsibilities. Using a car industry analogy, this article helps you understand the positioning and collaboration of Packer, Terraform, Ansible, Docker, and Kubernetes all at once.
 tags:


### PR DESCRIPTION
## Problems with the old page

Measured against standard resume-writing practice, the old version undersold its author:

1. **Star-rating skill bars are a known anti-pattern** — self-assessed and unverifiable, and a `Go ★★★☆☆` row actively advertises a weakness
2. **Internal jargon** — "Scan → Try → Scale" means nothing to a recruiter
3. **Almost nothing quantified** — apart from one line about cpp-linter adoption, no numbers anywhere
4. **A seven-bullet summary** with no hook and low information density
5. **Self-contradiction in the Chinese version** — "focused on DevOps since 2018" two paragraphs above a job history that starts DevOps in 2015

## Approach: build everything on verifiable facts

Sources were checked before writing: the adopter names on the cpp-linter-action repository page, organization membership on the GitHub profile, and first-hand records on this blog for the EuroPython review role and the Anthropic program. Star counts are deliberately **not** baked in — they age quickly, while "runs in Microsoft's and NASA's CI" stays true.

New structure (both languages in sync):

- **Two-paragraph positioning statement** + highlights: cpp-linter adopted by Microsoft / Apache / NASA / Samsung / Bloomberg / Qualcomm, official Jenkins plugin author, Anthropic Open Source Developer Program (2026), EuroPython 2025 proposal reviewer, 250+ original articles
- **Work experience** leads with outcomes; the two pre-2015 roles compress to one line each
- **Open source**: five flagship projects, one paragraph each (including Open Delivery Spec — the CI gate this very repository runs on every PR), the rest in a single "More" line
- **Skills** grouped into four categories, star ratings removed
- **Community** section for conference and ecosystem roles
- **Contact** with the previously missing GitHub link

## Revisions from review

- Removed all mentions of the weekly newsletter (no longer publishing)
- Current role generalized to **agentic application development** — no internal project names; AI code review stays as a work item and a skill, not a product name
- **Kubernetes removed from skills** (kept in the 2015–2024 history where the deployment work actually happened; listing it as a skill overstated proficiency next to Docker)
- "Six GitHub organizations" → "a number of open source organizations and projects" (the six included one where the relationship is membership, not ownership)
- Removed the Arctic Code Vault badge and the sales-pitch closing line

## Incidental fix

Two English posts (`2025-summary`, `devops-tools`) were missing the opening front matter delimiter, so Hugo rendered their metadata as body text with a `0001-01-01` date — visible as broken cards in this page's Related section. Both get their leading `---` back; they were the only two such files in the repository.

## Verification

- `hugo --gc --minify` passes clean
- Full-page screenshots checked for both languages; TOC, anchors, and author card intact
- The broken Related cards are gone