### PR TITLE
fix: remove slashes from tag names so taxonomy URLs stop colliding

### DIFF
--- a/.github/scripts/tests/test_tags.py
+++ b/.github/scripts/tests/test_tags.py
@@ -1,0 +1,97 @@
+"""Structural checks on post tags.
+
+Tags become URLs, so a few characters and spellings break the taxonomy in
+ways that are invisible in the front matter and only show up as a wrong page
+on the live site. These guard the two failures this repository has actually
+hit.
+"""
+
+import os
+import re
+import sys
+from collections import defaultdict
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+CONTENT = os.path.join(REPO_ROOT, "content")
+SECTIONS = ("posts", "misc")
+
+
+def tags_by_file():
+    """Map each content file to the tag list in its front matter."""
+    found = {}
+    for section in SECTIONS:
+        for d, _, files in os.walk(os.path.join(CONTENT, section)):
+            for f in files:
+                if not (f.startswith("index") and f.endswith(".md")):
+                    continue
+                path = os.path.join(d, f)
+                with open(path, encoding="utf-8") as fh:
+                    m = re.search(r"^---\n(.*?)\n---", fh.read(), re.S)
+                if not m:
+                    continue
+                tags, collecting = [], False
+                for line in m.group(1).split("\n"):
+                    if re.match(r"^tags:\s*$", line):
+                        collecting = True
+                        continue
+                    if collecting:
+                        if re.match(r"^\s*-\s+", line):
+                            tags.append(line.split("-", 1)[1].strip().strip("\"'"))
+                        elif re.match(r"^\S", line):
+                            break
+                if tags:
+                    found[os.path.relpath(path, REPO_ROOT)] = tags
+    return found
+
+
+ALL_TAGS = tags_by_file()
+
+
+def test_content_was_found():
+    # A silent zero here would make every other check vacuously pass.
+    assert len(ALL_TAGS) > 100, f"only found {len(ALL_TAGS)} tagged files — walk is broken"
+
+
+def test_no_slash_in_tag():
+    """A slash turns one term into a nested URL that collides with its parent.
+
+    'CI/CD' rendered at /tags/ci/cd/, which made the sibling tag 'CI' at
+    /tags/ci/ swallow its posts and mislabel itself in the term list.
+    """
+    offenders = {f: [t for t in tags if "/" in t] for f, tags in ALL_TAGS.items()}
+    offenders = {f: t for f, t in offenders.items() if t}
+    assert not offenders, f"tags containing '/' break taxonomy URLs: {offenders}"
+
+
+def test_no_case_only_duplicates():
+    """Two spellings of one tag split its posts across two term pages."""
+    by_lower = defaultdict(set)
+    for tags in ALL_TAGS.values():
+        for t in tags:
+            by_lower[t.lower()].add(t)
+    dupes = {k: sorted(v) for k, v in by_lower.items() if len(v) > 1}
+    assert not dupes, f"tags differing only by case: {dupes}"
+
+
+def test_no_leading_or_trailing_whitespace():
+    offenders = {
+        f: [t for t in tags if t != t.strip()] for f, tags in ALL_TAGS.items()
+    }
+    offenders = {f: t for f, t in offenders.items() if t}
+    assert not offenders, f"tags with stray whitespace: {offenders}"
+
+
+def test_no_empty_tags():
+    offenders = {f: tags for f, tags in ALL_TAGS.items() if any(not t for t in tags)}
+    assert not offenders, f"empty tag entries: {offenders}"
+
+
+def test_no_duplicate_tag_within_a_post():
+    offenders = {
+        f: tags for f, tags in ALL_TAGS.items() if len(tags) != len(set(tags))
+    }
+    assert not offenders, f"the same tag listed twice in one post: {offenders}"
+
+
+if __name__ == "__main__":
+    sys.exit("run with pytest")

--- a/content/posts/2020/ci-cd-tools/index.md
+++ b/content/posts/2020/ci-cd-tools/index.md
@@ -2,7 +2,7 @@
 title: 2021 年务必知道的最好用的 14 款 CI/CD 工具
 summary: 本文列出了市场上最流行的 14 种 CI/CD 工具，包括 Jenkins、CircleCI、TeamCity 等，并介绍了它们的主要特性和使用场景。
 tags:
-  - CI/CD
+  - CI-CD
 date: 2020-03-29
 aliases:
   - /2020/03/ci-cd-tools/

--- a/content/posts/2021/cicd-assessment/index.md
+++ b/content/posts/2021/cicd-assessment/index.md
@@ -2,7 +2,7 @@
 title: 组织内如何评估 CI/CD 成熟度
 summary: 本文介绍了如何使用 Jenkins 的 generic-webhook-trigger 插件来实时获取 Bitbucket 仓库的事件信息，如 Pull Request ID 等。
 tags:
-  - CI/CD
+  - CI-CD
   - Badge
 translate: false
 date: 2021-12-07

--- a/content/posts/2022/jenkins-skip-ci/index.en.md
+++ b/content/posts/2022/jenkins-skip-ci/index.en.md
@@ -3,7 +3,7 @@ title: How to implement [skip ci] for Jenkins multi-branch pipeline
 summary: |
   This article explains how to implement [skip ci] functionality in Jenkins multi-branch pipelines, allowing you to skip builds based on commit messages.
 tags:
-  - CI
+  - CI-CD
   - Jenkins
 authors:
   - shenxianpeng

--- a/content/posts/2022/jenkins-skip-ci/index.md
+++ b/content/posts/2022/jenkins-skip-ci/index.md
@@ -3,7 +3,7 @@ title: 如何在 Jenkins 多分支流水线中实现 [skip ci]
 summary: |
   本文介绍如何在 Jenkins 多分支流水线中实现 [skip ci] 功能，根据提交信息跳过构建。
 tags:
-  - CI
+  - CI-CD
   - Jenkins
 authors:
 aliases:

--- a/content/posts/2025/code-refactor/index.en.md
+++ b/content/posts/2025/code-refactor/index.en.md
@@ -3,7 +3,7 @@ title: CI/CD—Not a One-Time Project, but a Continuously Evolving System
 summary: |
   In DevOps, CI/CD pipelines require continuous maintenance and refactoring. This article explores why CI/CD is not a one-time construction project, but a system that requires long-term investment and continuous evolution.
 tags:
-  - CI/CD
+  - CI-CD
   - DevOps
 authors:
   - shenxianpeng

--- a/content/posts/2025/code-refactor/index.md
+++ b/content/posts/2025/code-refactor/index.md
@@ -3,7 +3,7 @@ title: CI/CD 不是一次性的项目，而是一个不断演进的系统
 summary: |
   在 DevOps 中，CI/CD 流水线需要持续维护和重构。本文探讨了为什么 CI/CD 不是一次性的建设项目，而是一个需要长期投入和持续演进的系统。
 tags:
-  - CI/CD
+  - CI-CD
   - DevOps
 authors:
   - shenxianpeng

--- a/content/posts/2026/cpp-linter-hooks/index.en.md
+++ b/content/posts/2026/cpp-linter-hooks/index.en.md
@@ -4,7 +4,7 @@ summary: |
   C/C++ tooling in the pre-commit ecosystem has long been limited. cpp-linter-hooks is currently the only pre-commit hook that supports both clang-format and clang-tidy, with built-in compilation database auto-detection, version pinning, and auto-fix capabilities.
 tags:
   - pre-commit
-  - C/C++
+  - C++
   - Open Source
 authors:
   - shenxianpeng

--- a/content/posts/2026/cpp-linter-hooks/index.md
+++ b/content/posts/2026/cpp-linter-hooks/index.md
@@ -4,7 +4,7 @@ summary: |
   pre-commit 生态里 C/C++ 的工具一直比较薄弱。cpp-linter-hooks 是目前唯一同时支持 clang-format 和 clang-tidy 的 pre-commit hook，还内置了编译数据库自动检测、版本锁定、自动修复等实用功能。本文介绍它的用法和设计思路。
 tags:
   - pre-commit
-  - C/C++
+  - C++
   - Open Source
 authors:
   - shenxianpeng


### PR DESCRIPTION
## The bug

The tags page listed **two entries both reading `CI/CD`** — one counting 4 posts, one counting 3 — and both linking to the same page.

A slash in a tag name makes Hugo build a **nested** URL. `CI/CD` landed at `/tags/ci/cd/`, which puts it *underneath* the sibling tag `CI` at `/tags/ci/`:

| URL | Should hold | Actually held | Listed as |
|---|---|---|---|
| `/tags/ci/` | 1 post (`jenkins-skip-ci`) | **4 posts** — absorbed CI/CD's | title `CI/CD`, link → `/tags/ci/cd/` |
| `/tags/ci/cd/` | 3 posts | 3 posts | correct |

Two consequences: `jenkins-skip-ci` was **unreachable** from the tags page, and whichever of the two identical-looking entries a reader clicked, they landed on the same 3-post page.

## The fix

- `CI/CD` → **`CI-CD`**, and the single-use `CI` tag folds into it. `/tags/ci-cd/` now holds all 4 posts, including the previously stranded one.
- `C/C++` → **`C++`**. Same defect, latent rather than live — no sibling `C` tag existed to collide with, but the nested URL was the same trap.

Verified after rebuild: `/tags/ci/`, `/tags/ci/cd/` and `/tags/c/c/` are gone; the term list shows exactly one `CI-CD` (4 posts) and one `C++` (1 post).

## Preventing the next one

Adds `.github/scripts/tests/test_tags.py`, which scans every post's front matter and asserts:

- **no slashes** in tag names — the bug above
- **no case-only duplicate spellings** — the class fixed in #408 (`python`/`Python`, `Clang`/`clang`, …)
- no stray whitespace, no empty entries, no tag repeated within one post
- plus a guard that the walk actually found content, so a silent zero can't make every other check pass vacuously

Restoring the slash to one post fails `test_no_slash_in_tag` and nothing else — verified by mutation, not assumed. Suite is 38 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae6nzq8QQXqzdsigzF3ojY)_