### PR TITLE
fix: stop the About page recommending 2022 posts, localize the archive total

### DIFF
--- a/content/about/index.en.md
+++ b/content/about/index.en.md
@@ -8,6 +8,7 @@ showDateOnlyInArticle : false
 showDateUpdated : false
 showHeadingAnchors : false
 showPagination : false
+showRelatedContent : false
 showReadingTime : false
 showTableOfContents : true
 showTaxonomies : false 

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -8,6 +8,7 @@ showDateOnlyInArticle : false
 showDateUpdated : false
 showHeadingAnchors : false
 showPagination : false
+showRelatedContent : false
 showReadingTime : false
 showTableOfContents : true
 showTaxonomies : false 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -78,3 +78,7 @@ shortcode:
 
 recent:
   show_more: "Show More"
+
+archive_total:
+  one: "{{ .Count }} post"
+  other: "{{ .Count }} posts"

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -65,3 +65,6 @@ shortcode:
 
 recent:
   show_more: "显示更多"
+
+archive_total:
+  other: "共 {{ .Count }} 篇"

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -65,3 +65,6 @@ shortcode:
 
 recent:
   show_more: "显示更多"
+
+archive_total:
+  other: "共 {{ .Count }} 篇"

--- a/layouts/archive/list.html
+++ b/layouts/archive/list.html
@@ -13,36 +13,31 @@
         </p>
       {{ end }}
     </header>
+    {{ $posts := where .Site.RegularPages "Section" "in" (slice "posts" "misc") }}
+    {{/* Drop pages Hugo dated to year 1 because their front matter is malformed */}}
+    {{ $posts = where $posts "Date.Year" "gt" 1000 }}
+    <p class="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+      {{ i18n "archive_total" (len $posts) }}
+    </p>
     <section class="max-w-full mt-6 prose dark:prose-invert">
       {{ .Content }}
     </section>
 
     {{/* Auto-generate archive list by year */}}
     <section class="mt-12">
-      {{/* Get all posts from posts and misc sections */}}
-      {{ $posts := where .Site.RegularPages "Section" "in" (slice "posts" "misc") }}
-      {{/* Filter out pages without valid dates (year > 1000) */}}
-      {{ $posts = where $posts "Date.Year" "gt" 1000 }}
-      
-      <h2 class="text-2xl font-bold mb-6 text-neutral-900 dark:text-neutral">
-        Archive
-        <span class="ml-3 text-lg text-neutral-500 dark:text-neutral-400 font-normal">
-          ({{ len $posts }})
-        </span>
-      </h2>
-      
-      {{/* Group posts by year */}}
+      {{/* Group posts by year. The year is the first heading under the page
+           title: an "Archive" heading here would only repeat that title. */}}
       {{ range $posts.GroupByDate "2006" "desc" }}
         <div class="mb-10" id="{{ .Key }}">
-          <h3 class="text-xl font-semibold mb-6 flex items-baseline">
+          <h2 class="text-xl font-semibold mb-6 flex items-baseline">
             <a href="#{{ .Key }}" class="text-primary-600 dark:text-primary-400 hover:underline">
               {{ .Key }}
             </a>
             <span class="ml-2 text-base text-neutral-500 dark:text-neutral-400">
               ({{ len .Pages }})
             </span>
-          </h3>
-          
+          </h2>
+
           {{/* List all articles for this year */}}
           <ul class="space-y-3 ml-4">
             {{ range .Pages.ByDate.Reverse }}


### PR DESCRIPTION
Two unrelated defects on non-article pages.

## 1. About page recommended six posts from spring 2022

Paternity leave, WSL, Docker, Jenkins LDAP, Fork, Groovy — which reads as a blog that stopped updating four years ago, while 2026 alone has 44 posts.

**The cause is narrower than "it has no tags."** With `[related] threshold = 0` and the page carrying no `tags`, `categories`, `series` or `authors`, the only index left to score on is `date` (weight 10) — and that ranks by **proximity to the page's own date**. About is dated `2022-06-13`, so Hugo was faithfully recommending posts near June 2022. Not stale data; working exactly as configured, on a page that should not have been asking.

An About page is a destination, not an article, so `showRelatedContent` is switched off in both languages rather than given tags it does not want.

## 2. Archive page repeated its own title in the wrong language

The layout hardcoded an `Archive (257)` heading directly beneath the page title, so:

| | Title | Heading below it |
|---|---|---|
| 中文 | 文章归档 | `Archive (257)` ← mixed scripts |
| English | Archive | `Archive (257)` ← said twice |

The heading carried no information the title didn't, except the count. So:

- the count becomes a localized line under the description — **共 257 篇** / **176 posts** (new `archive_total` key in all three i18n files)
- the redundant heading is removed
- year headings move from `h3` to `h2`, so the page no longer skips a heading level

## Verification

`hugo --gc --minify` clean. Both languages screenshot-checked: the archive reads title → description → count → year groups, and About now ends at the author card with no related section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae6nzq8QQXqzdsigzF3ojY)_