### PR TITLE
fix: give the author pages something to say

### DIFF
--- a/content/authors/shenxianpeng/_index.en.md
+++ b/content/authors/shenxianpeng/_index.en.md
@@ -2,9 +2,11 @@
 title: "Xianpeng Shen"
 ---
 
-### Hi 👋, I'm Xianpeng  
+DevOps / AI engineer in Vilnius, Lithuania. I build delivery automation at
+Rocket Software, and maintain open source tooling — [cpp-linter](https://github.com/cpp-linter),
+[commit-check](https://github.com/commit-check),
+[conventional-branch](https://github.com/conventional-branch) — that runs in
+the CI of hundreds of projects.
 
-**Engineer. Builder. Maintainer.**
-
-
----
+Everything I've written is below. See the [resume](/en/hireme/) for the longer
+version, or [@shenxianpeng](https://github.com/shenxianpeng) for the code.

--- a/content/authors/shenxianpeng/_index.md
+++ b/content/authors/shenxianpeng/_index.md
@@ -2,12 +2,17 @@
 title: "沈显鹏"
 ---
 
-### 你好👋, 我是 Xianpeng
+DevOps / AI 工程师，现居立陶宛维尔纽斯。在 Rocket Software 做交付自动化，
+业余维护 [cpp-linter](https://github.com/cpp-linter)、[commit-check](https://github.com/commit-check)、
+[conventional-branch](https://github.com/conventional-branch) 等开源工具，
+它们跑在数百个项目的 CI 里。
 
-**Engineer. Builder. Maintainer.**
+我写过的文章都在下面。想看更完整的介绍见[简历](/hireme/)，看代码见
+[@shenxianpeng](https://github.com/shenxianpeng)。
 
-欢迎关注我的微信公众号👇
+<details>
+<summary>关注公众号「沈显鹏」</summary>
 
-![沈显鹏](/img/qrcode.jpg)
+![公众号「沈显鹏」二维码](/img/qrcode.jpg)
 
----
+</details>


### PR DESCRIPTION
## Correction to the original report

My review said the English author page showed a WeChat QR code. **It doesn't** — `_index.en.md` already exists separately and has no QR. The real problems turned out to be different:

| | Before |
|---|---|
| **English** | A greeting and the four-word tagline. Nothing else. |
| **Chinese** | Same opening, then a QR code rendered **800px tall** — the post list started below the fold on a 1280×820 laptop. |
| **Both** | A stray `---` producing an orphan rule under the tagline, duplicating the theme's own separator. |

Also, `Engineer. Builder. Maintainer.` already appears in the author card at the foot of every article, so repeating it as the page's entire content added nothing.

## Change

Each page now opens with two sentences that place the author — role, location, the open source tooling and where it runs — then points at the resume and GitHub. The QR code stays on the Chinese page but moves into a collapsed `<details>`: the posts a visitor came for are visible immediately, and the WeChat funnel is one click away for readers who want it.

## Verification

`hugo --gc --minify` clean. Both pages screenshot-checked at 1280×820: post cards now appear above the fold in both languages, and the orphan rule is gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae6nzq8QQXqzdsigzF3ojY)_